### PR TITLE
Fix version of Golang for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,45 @@
-language: go
 sudo: required
 
-go:
-    - 1.10
+services:
+    - docker
 
-go_import_path: github.com/clearlinux/clr-installer
+# This is just shere for Travis CI to report correctly
+language: go
+go:
+    - "1.10"
+
+# go_import_path: github.com/clearlinux/clr-installer
 
 before_install:
-    - sudo apt-get update -qq
-    - go get -u gopkg.in/alecthomas/gometalinter.v2
-    - gometalinter.v2 --install
+    - docker pull clearlinux
+    - docker run --network=host --name clear-test -v $(pwd):/travis -v /dev:/dev --privileged -dit --rm clearlinux:latest /sbin/init
+    - docker ps
+
+# we need both -l (login) and -c (command) for the bash shell
+# in order to ensure we read the .profile settings
+install:
+    - docker exec -it clear-test bash -lc "swupd info"
+    - docker exec -it clear-test bash -lc "swupd update"
+    - docker exec -it clear-test bash -lc "swupd bundle-add sysadmin-basic storage-utils network-basic go-basic-dev git telemetrics"
+    - docker exec -it clear-test bash -lc "echo export GOPATH=\$(go env GOPATH) >> \${HOME}/.profile"
+    - docker exec -it clear-test bash -lc "echo export PATH=\\\${PATH}:\\\${GOPATH}/bin >> \${HOME}/.profile"
+    - docker exec -it clear-test bash -lc "go get -u gopkg.in/alecthomas/gometalinter.v2"
+    - docker exec -it clear-test bash -lc "gometalinter.v2 --install"
+
+before_script:
+    # Telemetry is NOT working in the Docker images under Travis-CI
+    # Drop these tests for now
+    - docker exec -it clear-test bash -lc "cd /travis ; rm telemetry/telemetry_test.go"
+    - docker exec -it clear-test bash -lc "set;printenv"
+      # - docker exec -it clear-test bash -lc "systemctl status telemd.service;/bin/true"
+      # - docker exec -it clear-test bash -lc "journalctl|cat"
+      #- docker exec -it clear-test bash -lc "ls -l /var/spool/"
 
 script:
-    - make dist-clean
-    - make
-    - make lint
-    - make check
+    - docker exec -it clear-test bash -lc "cd /travis ; make dist-clean"
+    - docker exec -it clear-test bash -lc "cd /travis ; make"
+    - docker exec -it clear-test bash -lc "cd /travis ; make lint"
+    - docker exec -it clear-test bash -lc "cd /travis ; make check"
+
+after_script:
+    - docker container stop clear-test

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -16,26 +16,26 @@ import (
 func TestGoodURL(t *testing.T) {
 
 	if err := CheckURL("http://www.google.com"); err != nil {
-		t.Fatal("Good HTTP URL failed")
+		t.Fatalf("Good HTTP URL failed: %s", err)
 	}
 
 	if err := CheckURL("https://www.google.com"); err != nil {
-		t.Fatal("Good HTTPS URL failed")
+		t.Fatalf("Good HTTPS URL failed: %s", err)
 	}
 
 	if err := CheckURL("https://cdn.download.clearlinux.org/update/"); err != nil {
-		t.Fatal("Good Clear Linux HTTPS URL failed")
+		t.Fatalf("Good Clear Linux HTTPS URL failed: %s", err)
 	}
 }
 
 func TestBadURL(t *testing.T) {
 
 	if err := CheckURL("http://www.google.zonk"); err == nil {
-		t.Fatal("Bad HTTP URL passed incorrectly")
+		t.Fatalf("Bad HTTP URL passed incorrectly: %s", err)
 	}
 
 	if err := CheckURL("https://www.google.zonk"); err == nil {
-		t.Fatal("Bad HTTPS URL passed incorrectly")
+		t.Fatalf("Bad HTTPS URL passed incorrectly: %s", err)
 	}
 }
 

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -16,7 +16,7 @@ func TestGetHostMirror(t *testing.T) {
 	}
 
 	if _, err := GetHostMirror(); err != nil {
-		t.Fatal("Getting Host Mirror failed")
+		t.Fatalf("Getting Host Mirror failed: %s", err)
 	}
 }
 
@@ -30,7 +30,7 @@ func TestBadSetHostMirror(t *testing.T) {
 
 	mirror := "http://www.google.com"
 	if _, err := SetHostMirror(mirror); err == nil {
-		t.Fatal("Setting Bad Host Mirror failed")
+		t.Fatalf("Setting Bad Host Mirror failed: %s", err)
 	}
 }
 
@@ -45,12 +45,12 @@ func TestGoodSetHostMirror(t *testing.T) {
 	mirror := "https://download.clearlinux.org/update/"
 	//mirror := "http://linux-ftp.jf.intel.com/pub/mirrors/clearlinux/update/"
 	if _, err := SetHostMirror(mirror); err != nil {
-		t.Fatal("Setting Good Host Mirror failed")
+		t.Fatalf("Setting Good Host Mirror failed: %s", err)
 	}
 
 	// Remove the mirror
 	if _, err := UnSetHostMirror(); err != nil {
-		t.Fatal("Unsetting Good Host Mirror failed")
+		t.Fatalf("Unsetting Good Host Mirror failed: %s", err)
 	}
 }
 


### PR DESCRIPTION
Fixes Issue: 
Setting to 1.10 get parsed as a float and interrupted as 1.1 instead of 1.10.
See: https://github.com/travis-ci/travis-ci/issues/9247

Changes proposed in this pull request:
- Adding quotes so it is treated as a string.
