### PR TITLE
Allow Rescanning of Media

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -414,6 +414,13 @@ func listBlockDevices(userDefined []*BlockDevice) ([]*BlockDevice, error) {
 	return merged, nil
 }
 
+// RescanBlockDevices Clear current list available block devices and rescans
+func RescanBlockDevices(userDefined []*BlockDevice) ([]*BlockDevice, error) {
+	avBlockDevices = nil
+
+	return ListAvailableBlockDevices(userDefined)
+}
+
 // ListAvailableBlockDevices Lists only available block devices
 // where available means block devices not mounted or not in use by the host system
 // userDefined will be inserted in the resulting list rather the loaded ones

--- a/tui/disk.go
+++ b/tui/disk.go
@@ -5,6 +5,8 @@
 package tui
 
 import (
+	"github.com/clearlinux/clr-installer/storage"
+
 	"github.com/VladimirMarkelov/clui"
 )
 
@@ -71,6 +73,16 @@ func newDiskPage(tui *Tui) (Page, error) {
 	mBtn.SetAlign(AlignLeft)
 	mBtn.OnClick(func(ev clui.Event) {
 		page.GotoPage(TuiPageManualPart)
+	})
+
+	rBtn := CreateSimpleButton(page.cFrame, AutoSize, AutoSize, "Rescan Media", Fixed)
+	rBtn.OnClick(func(ev clui.Event) {
+		_, err := storage.RescanBlockDevices(page.getModel().TargetMedias)
+		if err != nil {
+			page.Panic(err)
+		}
+
+		page.GotoPage(TuiPageDiskMenu)
 	})
 
 	page.activated = gBtn


### PR DESCRIPTION
Changes proposed in this pull request:
- If a USB drive is added or removed, this allow discovery without restarting the installation program.

