### PR TITLE
controller: don't reconfigure network

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -94,10 +94,6 @@ func Install(rootDir string, model *model.SystemInstall) error {
 		return err
 	}
 
-	if err = ConfigureNetwork(model); err != nil {
-		return err
-	}
-
 	mountPoints := []*storage.BlockDevice{}
 
 	// prepare all the target block devices


### PR DESCRIPTION
Now we have the network check dialog and we don't need/want to re
test the network in the install process.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>