### PR TITLE
testsuite: prepare to enable check-coverage.sh on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
     - docker exec -it clear-test bash -c "cd /travis ; make"
     - docker exec -it clear-test bash -c "cd /travis ; make lint"
     - travis_retry docker exec -it clear-test bash -c "cd /travis ; make check"
+    - travis_retry docker exec -it clear-test bash -c "cd /travis ; ./tests/check-coverage.sh"
 
 after_script:
     - docker container stop clear-test

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -20,6 +20,7 @@ var (
 
 func init() {
 	testHTTPPort = os.Getenv("TEST_HTTP_PORT")
+	_ = os.Setenv(logFileEnvironVar, "")
 }
 
 func makeTestKernelCmd(cmd string) (string, error) {
@@ -80,6 +81,23 @@ func TestParseArgsKernelCmdInvalidFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("Failed to detect a valid error reading kernel command")
 	}
+}
+
+func TestTelemetry(t *testing.T) {
+	var testArgs Args
+	var err error
+
+	currArgs := make([]string, len(os.Args))
+	copy(currArgs, os.Args)
+
+	os.Args = append(os.Args, "--telemetry-url=http://telemetry")
+
+	err = testArgs.ParseArgs()
+	if err == nil {
+		t.Fatal("Telemetry should require both --telemetry-url and --telemetry-tid")
+	}
+
+	os.Args = currArgs
 }
 
 func TestKernelCmdDemoTrue(t *testing.T) {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -227,4 +227,9 @@ func TestWriteFile(t *testing.T) {
 	if err := loaded.WriteFile(path); err != nil {
 		t.Fatal("Failed to write descriptor, should be valid")
 	}
+
+	// test writing to an invalid file
+	if err := loaded.WriteFile("/invalid-dir/invalid.yaml"); err == nil {
+		t.Fatal("Should have failed writing to an invalid file")
+	}
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -10,6 +10,17 @@ import (
 	"text/template"
 )
 
+func TestGetDeviceFile(t *testing.T) {
+	bd := &BlockDevice{Name: "sda"}
+	expected := "/dev/sda"
+
+	df := bd.GetDeviceFile()
+	if df != expected {
+		t.Fatalf("GetDeviceFile() returned wrong device file, returned: %s, expected: %s",
+			df, expected)
+	}
+}
+
 func TestSupportedFileSystem(t *testing.T) {
 	expected := []string{"btrfs", "ext2", "ext3", "ext4", "swap", "vfat", "xfs"}
 	supported := SupportedFileSystems()

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -76,3 +76,10 @@ func TestIsCoreBundle(t *testing.T) {
 		}
 	}
 }
+
+func TestParseSwupdMirrorInvalid(t *testing.T) {
+	_, err := parseSwupdMirror([]byte(""))
+	if err == nil {
+		t.Error("Should fail to parse empty string")
+	}
+}

--- a/tests/check-coverage.sh
+++ b/tests/check-coverage.sh
@@ -32,6 +32,7 @@ for key in ${!ccoverage[@]}; do
 
     if [[ ${ncov/.} < ${ccov/.} ]]; then
         echo "FATAL: decreased coverage for: $key - was: $ccov, now: $ncov"
+        rm $tmp
         exit 1
     fi
 done

--- a/tests/coverage-curr-status
+++ b/tests/coverage-curr-status
@@ -1,24 +1,24 @@
 go test -cover github.com/clearlinux/clr-installer/...
-ok  	github.com/clearlinux/clr-installer/args	0.183s	coverage: 90.9% of statements
+ok  	github.com/clearlinux/clr-installer/args	0.395s	coverage: 90.8% of statements
 ?   	github.com/clearlinux/clr-installer/clr-installer	[no test files]
 ?   	github.com/clearlinux/clr-installer/cmd	[no test files]
 ?   	github.com/clearlinux/clr-installer/conf	[no test files]
 ?   	github.com/clearlinux/clr-installer/controller	[no test files]
 ?   	github.com/clearlinux/clr-installer/crypt	[no test files]
-ok  	github.com/clearlinux/clr-installer/errors	0.001s	coverage: 92.0% of statements
+ok  	github.com/clearlinux/clr-installer/errors	0.002s	coverage: 92.0% of statements
 ?   	github.com/clearlinux/clr-installer/frontend	[no test files]
-ok  	github.com/clearlinux/clr-installer/hostname	0.005s	coverage: 100.0% of statements
+ok  	github.com/clearlinux/clr-installer/hostname	0.006s	coverage: 100.0% of statements
 ?   	github.com/clearlinux/clr-installer/kernel	[no test files]
 ?   	github.com/clearlinux/clr-installer/keyboard	[no test files]
 ?   	github.com/clearlinux/clr-installer/language	[no test files]
-ok  	github.com/clearlinux/clr-installer/log	0.009s	coverage: 100.0% of statements
+ok  	github.com/clearlinux/clr-installer/log	0.008s	coverage: 100.0% of statements
 ?   	github.com/clearlinux/clr-installer/massinstall	[no test files]
-ok  	github.com/clearlinux/clr-installer/model	0.005s	coverage: 94.6% of statements
-ok  	github.com/clearlinux/clr-installer/network	8.727s	coverage: 53.1% of statements
+ok  	github.com/clearlinux/clr-installer/model	0.005s	coverage: 93.5% of statements
+ok  	github.com/clearlinux/clr-installer/network	0.724s	coverage: 53.1% of statements
 ?   	github.com/clearlinux/clr-installer/progress	[no test files]
-ok  	github.com/clearlinux/clr-installer/storage	0.012s	coverage: 27.8% of statements
-ok  	github.com/clearlinux/clr-installer/swupd	0.005s	coverage: 15.7% of statements
-?   	github.com/clearlinux/clr-installer/telemetry	[no test files]
+ok  	github.com/clearlinux/clr-installer/storage	0.011s	coverage: 27.9% of statements
+ok  	github.com/clearlinux/clr-installer/swupd	0.005s	coverage: 16.2% of statements
+ok  	github.com/clearlinux/clr-installer/telemetry	0.361s	coverage: 35.6% of statements
 ?   	github.com/clearlinux/clr-installer/timezone	[no test files]
 ?   	github.com/clearlinux/clr-installer/tui	[no test files]
 ?   	github.com/clearlinux/clr-installer/user	[no test files]


### PR DESCRIPTION
This patch fixes the tests coverage regressions and add a small fix
to the script where it doesn't remove the temporary coverage report
file if it fails. Now it can be enabled on the CI and avoid adding
new testsuite regressions.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>