### PR TITLE
Enable Escape key to cancel to previous page

### DIFF
--- a/tui/common.go
+++ b/tui/common.go
@@ -327,6 +327,19 @@ func (page *BasePage) setup(tui *Tui, id int, btns int, returnID int) {
 		"Use [Tab] or the arrow keys [up and down] to navigate", Fixed)
 
 	page.window.SetVisible(false)
+
+	// Escape-key cancel's this screen and returns
+	// same as the default 'Cancel' button
+	page.window.OnKeyDown(func(ev clui.Event, data interface{}) bool {
+		if ev.Key == term.KeyEsc {
+			page.action = ActionCancelButton
+			page.GotoPage(returnID)
+			page.action = ActionNone
+			return true
+		}
+
+		return false
+	}, nil)
 }
 
 func (page *BasePage) newWindow() {


### PR DESCRIPTION
Fixes Issue: #53

Changes proposed in this pull request:
- Trap on the Escape-key on the common page type; reacts like the default 'Cancel' key to return to the "previous" page as defined by page setup.

