### PR TITLE
kernel arguments: add "remove kernel arguments" support

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -143,10 +143,24 @@ func Install(rootDir string, model *model.SystemInstall) error {
 		model.AddBundle("telemetrics")
 	}
 
-	if model.KernelCMDLine != "" {
+	if model.KernelArguments != nil && len(model.KernelArguments.Add) > 0 {
 		cmdlineDir := filepath.Join(rootDir, "etc", "kernel")
 		cmdlineFile := filepath.Join(cmdlineDir, "cmdline")
-		cmdline := model.KernelCMDLine
+		cmdline := strings.Join(model.KernelArguments.Add, " ")
+
+		if err = utils.MkdirAll(cmdlineDir, 0755); err != nil {
+			return err
+		}
+
+		if err = ioutil.WriteFile(cmdlineFile, []byte(cmdline), 0644); err != nil {
+			return err
+		}
+	}
+
+	if model.KernelArguments != nil && len(model.KernelArguments.Remove) > 0 {
+		cmdlineDir := filepath.Join(rootDir, "etc", "kernel", "cmdline-removal.d")
+		cmdlineFile := filepath.Join(cmdlineDir, "clr-installer.conf")
+		cmdline := strings.Join(model.KernelArguments.Remove, " ")
 
 		if err = utils.MkdirAll(cmdlineDir, 0755); err != nil {
 			return err

--- a/kernel/kernel.go
+++ b/kernel/kernel.go
@@ -20,6 +20,13 @@ type Kernel struct {
 	userDefined bool
 }
 
+// Arguments defines the set of arguments to be added and/or removed
+// from the list of kernel comand line arguments
+type Arguments struct {
+	Add    []string // Add is the set of arguments to be added
+	Remove []string // Remove is the set of arguments to be removed
+}
+
 // LoadKernelList loads the kernel definitions
 func LoadKernelList() ([]*Kernel, error) {
 	path, err := conf.LookupKernelListFile()

--- a/model/model.go
+++ b/model/model.go
@@ -19,6 +19,7 @@ import (
 	"github.com/clearlinux/clr-installer/telemetry"
 	"github.com/clearlinux/clr-installer/timezone"
 	"github.com/clearlinux/clr-installer/user"
+	"github.com/clearlinux/clr-installer/utils"
 )
 
 // Version of Clear Installer.
@@ -39,7 +40,7 @@ type SystemInstall struct {
 	Telemetry         *telemetry.Telemetry   `yaml:"telemetry,omitempty,flow"`
 	Timezone          *timezone.TimeZone     `yaml:"timezone,omitempty,flow"`
 	Users             []*user.User           `yaml:"users,omitempty,flow"`
-	KernelCMDLine     string                 `yaml:"kernel-cmdline,omitempty,flow"`
+	KernelArguments   *kernel.Arguments      `yaml:"kernel-arguments,omitempty,flow"`
 	Kernel            *kernel.Kernel         `yaml:"kernel,omitempty,flow"`
 	PostReboot        bool                   `yaml:"postReboot,omitempty,flow"`
 	SwupdMirror       string                 `yaml:"swupdMirror,omitempty,flow"`
@@ -49,6 +50,39 @@ type SystemInstall struct {
 	TelemetryURL      string                 `yaml:"telemetryURL,omitempty,flow"`
 	TelemetryTID      string                 `yaml:"telemetryTID,omitempty,flow"`
 	TelemetryPolicy   string                 `yaml:"telemetryPolicy,omitempty,flow"`
+}
+
+// AddExtraKernelArguments adds a set of custom extra kernel arguments to be added to the
+// clr-boot-manager configuration
+func (si *SystemInstall) AddExtraKernelArguments(args []string) {
+	if si.KernelArguments == nil {
+		si.KernelArguments = &kernel.Arguments{}
+	}
+
+	for _, curr := range args {
+		if utils.StringSliceContains(si.KernelArguments.Add, curr) {
+			continue
+		}
+
+		si.KernelArguments.Add = append(si.KernelArguments.Add, curr)
+	}
+}
+
+// RemoveKernelArguments adds a set of kernel arguments to be "black listed" on
+// clear-boot-manager, meaning these arguments will never end up in the boot manager
+// entry configuration
+func (si *SystemInstall) RemoveKernelArguments(args []string) {
+	if si.KernelArguments == nil {
+		si.KernelArguments = &kernel.Arguments{}
+	}
+
+	for _, curr := range args {
+		if utils.StringSliceContains(si.KernelArguments.Remove, curr) {
+			continue
+		}
+
+		si.KernelArguments.Remove = append(si.KernelArguments.Remove, curr)
+	}
 }
 
 // ContainsBundle returns true if the data model has a bundle and false otherwise

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -233,3 +233,63 @@ func TestWriteFile(t *testing.T) {
 		t.Fatal("Should have failed writing to an invalid file")
 	}
 }
+
+func TestAddExtraKernelArguments(t *testing.T) {
+	args := []string{"arg1", "arg2", "arg3"}
+
+	si := &SystemInstall{}
+	si.AddExtraKernelArguments(args)
+
+	if si.KernelArguments == nil {
+		t.Fatal("AddExtraKernelArguments() should had created a KernelArguments object")
+	}
+
+	if len(si.KernelArguments.Add) != len(args) {
+		t.Fatal("AddExtraKernelArguments() didn't add all requested arguments")
+	}
+
+	for _, curr := range args {
+		if !utils.StringSliceContains(si.KernelArguments.Add, curr) {
+			t.Fatal("AddExtraKernelArguments() didn't add all the requested arguments")
+		}
+	}
+
+	l := len(si.KernelArguments.Add)
+
+	// testing duplication checks
+	si.AddExtraKernelArguments(args)
+
+	if l < len(si.KernelArguments.Add) {
+		t.Fatal("The duplication check has failed")
+	}
+}
+
+func TestRemoveKernelArguments(t *testing.T) {
+	args := []string{"arg1", "arg2", "arg3"}
+
+	si := &SystemInstall{}
+	si.RemoveKernelArguments(args)
+
+	if si.KernelArguments == nil {
+		t.Fatal("RemoveKernelArguments() should had created a KernelArguments object")
+	}
+
+	if len(si.KernelArguments.Remove) != len(args) {
+		t.Fatal("RemoveKernelArguments() didn't add all requested arguments")
+	}
+
+	for _, curr := range args {
+		if !utils.StringSliceContains(si.KernelArguments.Remove, curr) {
+			t.Fatal("RemoveKernelArguments() didn't add all the requested arguments")
+		}
+	}
+
+	l := len(si.KernelArguments.Remove)
+
+	// testing duplication check
+	si.RemoveKernelArguments(args)
+
+	if l < len(si.KernelArguments.Remove) {
+		t.Fatal("The duplication check has failed")
+	}
+}

--- a/tui/kernel_cmdline.go
+++ b/tui/kernel_cmdline.go
@@ -20,8 +20,9 @@ type KernelCMDLine struct {
 
 const (
 	kernelArgsHelp = `Note: The boot manager tool will first include the "Add Extra Arguments"
-      items, then the "Remove Arguments" items are removed. The final argument list contains the
-      kernel bundle's configured arguments and the ones configured by the user.`
+      items, then the "Remove Arguments" items are removed. The final
+      argument list contains the kernel bundle's configured arguments
+      and the ones configured by the user.`
 )
 
 // GetConfiguredValue Returns the string representation of currently value set

--- a/tui/kernel_cmdline.go
+++ b/tui/kernel_cmdline.go
@@ -20,9 +20,8 @@ type KernelCMDLine struct {
 
 const (
 	kernelArgsHelp = `Note: The boot manager tool will first include the "Add Extra Arguments"
-      items then the "Remove Arguments" items are removed from the final
-      - where the final list contains the kernel bundle's configured
-      arguments and the ones configured by the user.`
+      items, then the "Remove Arguments" items are removed. The final argument list contains the
+      kernel bundle's configured arguments and the ones configured by the user.`
 )
 
 // GetConfiguredValue Returns the string representation of currently value set

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -124,3 +124,13 @@ func IsRoot() bool {
 
 	return is
 }
+
+// StringSliceContains returns true if sl contains str, returns false otherwise
+func StringSliceContains(sl []string, str string) bool {
+	for _, curr := range sl {
+		if curr == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
We are relying on clr-boot-manager's cmdline-removal feature which
prevents a kernel argument to be added to the boot manager kernel
entry.

Fixes Issue: #18

Changes proposed in this pull request:
- Add remove kernel command line argument support