### PR TITLE
Enable Borders for PopUp Dialogue windows

### DIFF
--- a/tui/confirm_install.go
+++ b/tui/confirm_install.go
@@ -53,7 +53,7 @@ func initConfirmDiaglogWindow(dialog *ConfirmInstallDialog) error {
 
 	const title = "Confirm Installation"
 	const wBuff = 5
-	const hBuff = 4
+	const hBuff = 5
 	const dWidth = 50
 	const dHeight = 8
 
@@ -82,6 +82,7 @@ func initConfirmDiaglogWindow(dialog *ConfirmInstallDialog) error {
 	dialog.DialogBox.SetModal(true)
 	dialog.DialogBox.SetConstraints(dWidth, dHeight)
 	dialog.DialogBox.SetPack(clui.Vertical)
+	dialog.DialogBox.SetBorder(clui.BorderAuto)
 
 	borderFrame := clui.CreateFrame(dialog.DialogBox, dWidth, dHeight, clui.BorderNone, clui.Fixed)
 	borderFrame.SetPack(clui.Vertical)

--- a/tui/network_dialog_check.go
+++ b/tui/network_dialog_check.go
@@ -112,7 +112,7 @@ func initDiaglogWindow(dialog *NetworkTestDialog) error {
 
 	const title = "Testing Networking..."
 	const wBuff = 5
-	const hBuff = 4
+	const hBuff = 5
 	const dWidth = 50
 	const dHeight = 8
 
@@ -141,6 +141,7 @@ func initDiaglogWindow(dialog *NetworkTestDialog) error {
 	dialog.DialogBox.SetModal(true)
 	dialog.DialogBox.SetConstraints(dWidth, dHeight)
 	dialog.DialogBox.SetPack(clui.Vertical)
+	dialog.DialogBox.SetBorder(clui.BorderAuto)
 
 	borderFrame := clui.CreateFrame(dialog.DialogBox, dWidth, dHeight, clui.BorderNone, clui.Fixed)
 	borderFrame.SetPack(clui.Vertical)


### PR DESCRIPTION
Changes proposed in this pull request:
- Put borders back on the popup windows now that we are borderless

