### PR TITLE
local-travis: add a travis "emulation"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ script:
     - docker exec -it clear-test bash -c "chown -R travis:travis /travis"
     - docker exec --user "${DOCKER_USER}" -it clear-test bash -c "cd /travis ; make"
     - travis_retry docker exec --user "${DOCKER_USER}" -it clear-test bash -c "cd /travis ; ./tests/check-coverage.sh"
+    - docker exec -it clear-test bash -c "cd /travis ; make clean"
 
 after_script:
     - docker container stop clear-test

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ orig_go_path = $(shell go env GOPATH)
 export GOPATH=$(pkg_dir)
 export GO_PACKAGE_PREFIX := github.com/clearlinux/clr-installer
 export TESTS_DIR := $(top_srcdir)/tests/
+export TRAVIS_CONF = $(top_srcdir)/.travis.yml
+export UPDATE_COVERAGE = 1
 
 CLR_INSTALLER_TEST_HTTP_PORT ?= 8181
 
@@ -69,6 +71,12 @@ build-vendor: build
 build: gopath
 	go get -v ${GO_PACKAGE_PREFIX}/clr-installer
 	go install -v ${GO_PACKAGE_PREFIX}/clr-installer
+
+check-coverage: gopath
+	@go get -v ${GO_PACKAGE_PREFIX}/local-travis
+	@go install -v ${GO_PACKAGE_PREFIX}/local-travis
+	@echo "local-travis simulation:"
+	@$(top_srcdir)/.gopath/bin/local-travis
 
 check: gopath
 	go test -cover ${GO_PACKAGE_PREFIX}/...

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -86,6 +86,7 @@ func run(sw func(cmd *exec.Cmd) error, writer io.Writer, args ...string) error {
 
 	cmd.Stdout = writer
 	cmd.Stderr = writer
+	cmd.Stdin = os.Stdin
 
 	err := cmd.Run()
 	if err != nil {

--- a/local-travis/local-travis.go
+++ b/local-travis/local-travis.go
@@ -1,0 +1,270 @@
+// Copyright © 2018 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/clearlinux/clr-installer/cmd"
+
+	"gopkg.in/yaml.v2"
+)
+
+type travisConfig struct {
+	Env           []string `yaml:"env,omitempty"`
+	BeforeInstall []string `yaml:"before_install,omitempty"`
+	BeforeScript  []string `yaml:"before_script,omitempty"`
+	Script        []string `yaml:"script,omitempty"`
+	AfterScript   []string `yaml:"after_script,omitempty"`
+	envVars       [][]string
+}
+
+var (
+	cmdExp        = regexp.MustCompile(`\$\((?P<cmd>.*)\)`)
+	knownCommands = map[string]string{}
+)
+
+func (tc travisConfig) getEnvVar() [][]string {
+	res := [][]string{}
+
+	if tc.envVars != nil {
+		return tc.envVars
+	}
+
+	for _, curr := range tc.Env {
+		tks := strings.Split(curr, "=")
+		if len(tks) <= 1 {
+			continue
+		}
+
+		res = append(res, []string{tks[0], tks[1]})
+	}
+
+	tc.envVars = res
+	return res
+}
+
+func parseKnownCommands(line string) error {
+	match := cmdExp.FindStringSubmatch(line)
+
+	if len(match) > 0 {
+		for i := range cmdExp.SubexpNames() {
+			if i == 0 {
+				continue
+			}
+
+			cmdRepl := fmt.Sprintf("$(%s)", match[1])
+			if _, ok := knownCommands[cmdRepl]; ok {
+				continue
+			}
+
+			w := bytes.NewBuffer(nil)
+			if err := cmd.Run(w, strings.Split(match[1], " ")...); err != nil {
+				return err
+			}
+
+			knownCommands[cmdRepl] = strings.Replace(w.String(), "\n", "", -1)
+		}
+	}
+
+	return nil
+}
+
+func replaceCommandAndVars(cfg travisConfig, line string) (string, error) {
+	if err := parseKnownCommands(line); err != nil {
+		return "", err
+	}
+
+	repStr := map[string]string{}
+
+	// uses the line parsed expanded commands
+	for k, v := range knownCommands {
+		repStr[k] = v
+	}
+
+	// uses the travis declared env var
+	for _, evar := range cfg.getEnvVar() {
+		vars := []string{fmt.Sprintf("$%s", evar[0]), fmt.Sprintf("${%s}", evar[0])}
+
+		for _, curr := range vars {
+			repStr[strings.ToLower(curr)] = evar[1]
+			repStr[strings.ToUpper(curr)] = evar[1]
+		}
+	}
+
+	for k, v := range repStr {
+		if !strings.Contains(line, k) {
+			continue
+		}
+
+		line = strings.Replace(line, k, v, 1)
+	}
+
+	return line, nil
+}
+
+func splitArgs(cfg travisConfig, line string) ([]string, error) {
+	var token string
+	quoted := false
+	res := []string{}
+
+	line, err := replaceCommandAndVars(cfg, line)
+	if err != nil {
+		return nil, err
+	}
+
+	ll := len(line)
+
+	addToken := func(tk string) error {
+		if tk == "" {
+			return nil
+		}
+
+		res = append(res, tk)
+		return nil
+	}
+
+	for idx, ch := range line {
+		if ch == ' ' && !quoted {
+			if err := addToken(token); err != nil {
+				return nil, err
+			}
+
+			token = ""
+			continue
+		}
+
+		if ch == '"' {
+			if !quoted {
+				quoted = true
+				continue
+			} else {
+				if err := addToken(token); err != nil {
+					return nil, err
+				}
+				quoted = false
+				token = ""
+				continue
+			}
+		}
+
+		token = fmt.Sprintf("%s%c", token, ch)
+
+		if idx+1 == ll {
+			if err := addToken(token); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return res, nil
+}
+
+func addProxyToDocker(args []string) []string {
+	setVars := map[string]string{}
+	proxyVars := []string{"http_proxy", "https_proxy", "no_proxy"}
+
+	for _, pvar := range proxyVars {
+		value := os.Getenv(pvar)
+
+		if value == "" {
+			value = os.Getenv(strings.ToUpper(pvar))
+		}
+
+		if value != "" {
+			setVars[pvar] = value
+		}
+	}
+
+	if len(setVars) == 0 {
+		return args
+	}
+
+	res := []string{args[0], args[1]}
+
+	for k, v := range setVars {
+		res = append(res, []string{"-e", fmt.Sprintf("%s=%s", k, v)}...)
+	}
+
+	res = append(res, args[2:]...)
+	return res
+}
+
+func dockerCommandSupportsEnv(command string) bool {
+	for _, curr := range []string{"run", "exec"} {
+		if command == curr {
+			return true
+		}
+	}
+
+	return false
+}
+
+func runBatch(cfg travisConfig, batch []string) error {
+	for _, line := range batch {
+		args, err := splitArgs(cfg, line)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("running: [%s]\n", strings.Join(args, " "))
+
+		if args[0] == "travis_retry" {
+			args = args[1:]
+		}
+
+		if args[0] == "docker" && dockerCommandSupportsEnv(args[1]) {
+			args = addProxyToDocker(args)
+		}
+
+		if err := cmd.Run(os.Stdout, args...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	var cfg travisConfig
+	var panicError error
+
+	travisFile := os.Getenv("TRAVIS_CONF")
+	if travisFile == "" {
+		fmt.Println("ERROR: Could not find the travis config file, var $TRAVIS_CONF is not set")
+		os.Exit(1)
+	}
+
+	content, err := ioutil.ReadFile(travisFile)
+	if err != nil {
+		panic(err)
+	}
+
+	if yamlErr := yaml.Unmarshal(content, &cfg); yamlErr != nil {
+		panic(yamlErr)
+	}
+
+	cmds := [][]string{cfg.BeforeInstall, cfg.BeforeScript, cfg.Script}
+
+	for _, curr := range cmds {
+		if err := runBatch(cfg, curr); err != nil {
+			panicError = err
+			break
+		}
+	}
+
+	if err := runBatch(cfg, cfg.AfterScript); err != nil {
+		panic(err)
+	}
+
+	if panicError != nil {
+		panic(panicError)
+	}
+}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -73,6 +73,10 @@ func TestIpAddress(t *testing.T) {
 }
 
 func TestInterfaces(t *testing.T) {
+	if utils.IsCheckCoverage() {
+		t.Skip("Running on behalf of \"check-coverage\", skipping test")
+	}
+
 	ifaces, err := Interfaces()
 	if err != nil {
 		t.Fatal(err)
@@ -84,6 +88,10 @@ func TestInterfaces(t *testing.T) {
 }
 
 func TestYaml(t *testing.T) {
+	if utils.IsCheckCoverage() {
+		t.Skip("Running on behalf of \"check-coverage\", skipping test")
+	}
+
 	ifaces, err := Interfaces()
 	if err != nil {
 		t.Fatal(err)
@@ -100,6 +108,10 @@ func TestYaml(t *testing.T) {
 }
 
 func TestAddAddr(t *testing.T) {
+	if utils.IsCheckCoverage() {
+		t.Skip("Running on behalf of \"check-coverage\", skipping test")
+	}
+
 	list, err := Interfaces()
 	if err != nil {
 		t.Fatal(err)
@@ -162,6 +174,10 @@ func TestNetmaskToCID(t *testing.T) {
 func TestApply(t *testing.T) {
 	if !utils.IsRoot() {
 		t.Skip("Not running as 'root', skipping test")
+	}
+
+	if utils.IsCheckCoverage() {
+		t.Skip("Running on behalf of \"check-coverage\", skipping test")
 	}
 
 	dir, err := ioutil.TempDir("", "clr-installer-utest")

--- a/tests/coverage-curr-status
+++ b/tests/coverage-curr-status
@@ -1,24 +1,25 @@
 go test -cover github.com/clearlinux/clr-installer/...
-ok  	github.com/clearlinux/clr-installer/args	0.395s	coverage: 90.8% of statements
+ok  	github.com/clearlinux/clr-installer/args	0.590s	coverage: 90.8% of statements
 ?   	github.com/clearlinux/clr-installer/clr-installer	[no test files]
 ?   	github.com/clearlinux/clr-installer/cmd	[no test files]
 ?   	github.com/clearlinux/clr-installer/conf	[no test files]
 ?   	github.com/clearlinux/clr-installer/controller	[no test files]
 ?   	github.com/clearlinux/clr-installer/crypt	[no test files]
-ok  	github.com/clearlinux/clr-installer/errors	0.002s	coverage: 92.0% of statements
+ok  	github.com/clearlinux/clr-installer/errors	0.011s	coverage: 100.0% of statements
 ?   	github.com/clearlinux/clr-installer/frontend	[no test files]
-ok  	github.com/clearlinux/clr-installer/hostname	0.006s	coverage: 100.0% of statements
+ok  	github.com/clearlinux/clr-installer/hostname	0.003s	coverage: 100.0% of statements
 ?   	github.com/clearlinux/clr-installer/kernel	[no test files]
 ?   	github.com/clearlinux/clr-installer/keyboard	[no test files]
 ?   	github.com/clearlinux/clr-installer/language	[no test files]
-ok  	github.com/clearlinux/clr-installer/log	0.008s	coverage: 100.0% of statements
+?   	github.com/clearlinux/clr-installer/local-travis	[no test files]
+ok  	github.com/clearlinux/clr-installer/log	0.009s	coverage: 100.0% of statements
 ?   	github.com/clearlinux/clr-installer/massinstall	[no test files]
-ok  	github.com/clearlinux/clr-installer/model	0.005s	coverage: 93.5% of statements
-ok  	github.com/clearlinux/clr-installer/network	0.724s	coverage: 51.9% of statements
+ok  	github.com/clearlinux/clr-installer/model	0.005s	coverage: 94.5% of statements
+ok  	github.com/clearlinux/clr-installer/network	0.576s	coverage: 23.5% of statements
 ?   	github.com/clearlinux/clr-installer/progress	[no test files]
-ok  	github.com/clearlinux/clr-installer/storage	0.011s	coverage: 27.8% of statements
+ok  	github.com/clearlinux/clr-installer/storage	0.008s	coverage: 27.8% of statements
 ok  	github.com/clearlinux/clr-installer/swupd	0.005s	coverage: 16.2% of statements
-ok  	github.com/clearlinux/clr-installer/telemetry	0.361s	coverage: 35.6% of statements
+ok  	github.com/clearlinux/clr-installer/telemetry	0.316s	coverage: 35.6% of statements
 ?   	github.com/clearlinux/clr-installer/timezone	[no test files]
 ?   	github.com/clearlinux/clr-installer/tui	[no test files]
 ?   	github.com/clearlinux/clr-installer/user	[no test files]

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -134,3 +134,8 @@ func StringSliceContains(sl []string, str string) bool {
 	}
 	return false
 }
+
+// IsCheckCoverage returns true if CHECK_COVERAGE variable is set
+func IsCheckCoverage() bool {
+	return os.Getenv("CHECK_COVERAGE") != ""
+}


### PR DESCRIPTION
This patch introduces the local-travis, an small util program locally
emulate the remote travis execution. The program will read the travis
yaml file and execute the tasks.

The program is not intended to be manually executed but wrapped by
"make local-travis". The program uses the env var TRAVIS_CONFIG to
know where to find the travis yaml file (the makefile will have it all
set for you).

We also use the http_proxy, https_proxy and no_proxy if they are set.
If we're executing a docker command that supports -e flag then these
variables are also handled.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>

