### PR TITLE
model: add a minimal valid test

### DIFF
--- a/model/model_test.go
+++ b/model/model_test.go
@@ -37,6 +37,7 @@ func TestLoadFile(t *testing.T) {
 		{"no-telemetry.yaml", false},
 		{"real-example.yaml", true},
 		{"valid-network.yaml", true},
+		{"valid-minimal.yaml", true},
 	}
 
 	for _, curr := range tests {

--- a/tests/valid-minimal.yaml
+++ b/tests/valid-minimal.yaml
@@ -1,0 +1,25 @@
+#clear-linux-config
+targetMedia:
+- name: sda
+  size: "30752636928"
+  type: disk
+  children:
+  - name: sda1
+    fstype: vfat
+    mountpoint: /boot
+    size: "157286400"
+    type: part
+  - name: sda2
+    fstype: swap
+    size: "2147483648"
+    type: part
+  - name: sda3
+    fstype: ext4
+    mountpoint: /
+    size: "28447866880"
+    type: part
+bundles: [os-core, os-core-update]
+telemetry: false
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native


### PR DESCRIPTION
Introduce a minimal valid test, it shows the use of only the required
fields - specially for storage/media configurations.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>