### PR TITLE
post-install: add post-install hooks support

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -42,6 +42,12 @@ func RunAndLog(args ...string) error {
 	return Run(runLogger{}, args...)
 }
 
+// RunAndLogWithEnv does the same as RunAndLog but it changes the execution's environment
+// variables adding the provided ones by the env argument
+func RunAndLogWithEnv(env map[string]string, args ...string) error {
+	return run(nil, runLogger{}, env, args...)
+}
+
 // PipeRunAndLog is similar to RunAndLog runs a command and writes the output
 // to default logger and also writes in to the process stdin
 func PipeRunAndLog(in string, args ...string) error {
@@ -60,10 +66,10 @@ func PipeRunAndLog(in string, args ...string) error {
 		}()
 
 		return nil
-	}, runLogger{}, args...)
+	}, runLogger{}, nil, args...)
 }
 
-func run(sw func(cmd *exec.Cmd) error, writer io.Writer, args ...string) error {
+func run(sw func(cmd *exec.Cmd) error, writer io.Writer, env map[string]string, args ...string) error {
 	var exe string
 	var cmdArgs []string
 
@@ -88,6 +94,10 @@ func run(sw func(cmd *exec.Cmd) error, writer io.Writer, args ...string) error {
 	cmd.Stderr = writer
 	cmd.Stdin = os.Stdin
 
+	for k, v := range env {
+		cmd.Args = append(cmd.Args, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	err := cmd.Run()
 	if err != nil {
 		return err
@@ -99,5 +109,5 @@ func run(sw func(cmd *exec.Cmd) error, writer io.Writer, args ...string) error {
 // Run executes a command and uses writer to write both stdout and stderr
 // args are the actual command and its arguments
 func Run(writer io.Writer, args ...string) error {
-	return run(nil, writer, args...)
+	return run(nil, writer, nil, args...)
 }

--- a/model/model.go
+++ b/model/model.go
@@ -50,6 +50,14 @@ type SystemInstall struct {
 	TelemetryURL      string                 `yaml:"telemetryURL,omitempty,flow"`
 	TelemetryTID      string                 `yaml:"telemetryTID,omitempty,flow"`
 	TelemetryPolicy   string                 `yaml:"telemetryPolicy,omitempty,flow"`
+	PreInstall        []*InstallHook         `yaml:"pre-install,omitempty,flow"`
+	PostInstall       []*InstallHook         `yaml:"post-install,omitempty,flow"`
+}
+
+// InstallHook is a commands to be executed in a given point of the install process
+type InstallHook struct {
+	Chroot bool   `yaml:"chroot,omitempty,flow"`
+	Cmd    string `yaml:"cmd,omitempty,flow"`
 }
 
 // AddExtraKernelArguments adds a set of custom extra kernel arguments to be added to the

--- a/tests/post-install-sample.sh
+++ b/tests/post-install-sample.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "this is a simple post-install-sample and I only print if it's chrooted: $1"

--- a/tests/valid-minimal.yaml
+++ b/tests/valid-minimal.yaml
@@ -23,3 +23,14 @@ telemetry: false
 keyboard: us
 language: en_US.UTF-8
 kernel: kernel-native
+pre-install: [
+   {cmd: 'echo "running pre-install hook. dir: $chrootDir, chroot? $chrooted"'}
+]
+post-install: [
+   {cmd: "tests/post-install-sample.sh ${chrooted}"},
+   {chroot: true, cmd: 'echo "running: dir: $chrootDir, chrooted? $chrooted"'}
+]
+# post install commands will have a set of pre-defined variables expanded
+# currently supported variables are:
+#    chrootDir - the installation chrootDir (where the target system's media is mounted)
+#    chrooted  - set to 1 if the command is executed chrooted, 0 otherwise


### PR DESCRIPTION
Introduce the initial support to post-install hooks. The code also
expands a set of pre-defined variables, for now the only exposed
variable is the chrootDir (the directory where the target system is
mounted).

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>