### PR TITLE
model: add Version field

### DIFF
--- a/massinstall/massinstall.go
+++ b/massinstall/massinstall.go
@@ -120,6 +120,10 @@ func (mi *MassInstall) Run(md *model.SystemInstall, rootDir string) (bool, error
 
 	log.Debug("Starting install")
 
+	if md.Version > 0 {
+		fmt.Printf("Config file specifies a target \"version\", forcing auto-update off.")
+	}
+
 	instError = controller.Install(rootDir, md)
 	if instError != nil {
 		if !errors.IsValidationError(instError) {

--- a/model/model.go
+++ b/model/model.go
@@ -52,6 +52,7 @@ type SystemInstall struct {
 	TelemetryPolicy   string                 `yaml:"telemetryPolicy,omitempty,flow"`
 	PreInstall        []*InstallHook         `yaml:"pre-install,omitempty,flow"`
 	PostInstall       []*InstallHook         `yaml:"post-install,omitempty,flow"`
+	Version           uint                   `yaml:"version,omitempty,flow"`
 }
 
 // InstallHook is a commands to be executed in a given point of the install process
@@ -228,6 +229,10 @@ func LoadFile(path string) (*SystemInstall, error) {
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}
+	}
+
+	if result.Version > 0 {
+		result.AutoUpdate = false
 	}
 
 	return &result, nil

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -38,6 +38,7 @@ func TestLoadFile(t *testing.T) {
 		{"real-example.yaml", true},
 		{"valid-network.yaml", true},
 		{"valid-minimal.yaml", true},
+		{"valid-with-version.yaml", true},
 	}
 
 	for _, curr := range tests {

--- a/tests/valid-with-version.yaml
+++ b/tests/valid-with-version.yaml
@@ -1,0 +1,26 @@
+#clear-linux-config
+targetMedia:
+- name: sda
+  size: "30752636928"
+  type: disk
+  children:
+  - name: sda1
+    fstype: vfat
+    mountpoint: /boot
+    size: "157286400"
+    type: part
+  - name: sda2
+    fstype: swap
+    size: "2147483648"
+    type: part
+  - name: sda3
+    fstype: ext4
+    mountpoint: /
+    size: "28447866880"
+    type: part
+bundles: [os-core, os-core-update]
+telemetry: false
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native
+version: 1010


### PR DESCRIPTION
The mass-installer use case for image generation requires to specify
the target system version. This patch allows the configuration of
an arbitrary version.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>