### PR TITLE
build: add build target as lint dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,8 @@ update-linters:
 	fi \
 
 PHONY += lint
-lint: install-linters
+lint: build install-linters
+	@echo "Running linters"
 	@rm -rf ${LOCAL_GOPATH}/src/${GO_PACKAGE_PREFIX}/vendor
 	@cp -af vendor/* ${LOCAL_GOPATH}/src/
 	@gometalinter.v2 --deadline=10m --tests --vendor \


### PR DESCRIPTION
The lint target needs the project is built before actually running
linters, this patch makes the build target dependency of lint target.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>