### PR TITLE
travis: move final clean to after_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
     - docker exec -it clear-test bash -c "chown -R travis:travis /travis"
     - docker exec --user "${DOCKER_USER}" -it clear-test bash -c "cd /travis ; make"
     - travis_retry docker exec --user "${DOCKER_USER}" -it clear-test bash -c "cd /travis ; ./tests/check-coverage.sh"
-    - docker exec -it clear-test bash -c "cd /travis ; make clean"
 
 after_script:
+    - docker exec -it clear-test bash -c "cd /travis ; make clean"
     - docker container stop clear-test


### PR DESCRIPTION
The final build cleanup should be executed on after_script fase, that
way if any tests fails we still have the chance to clean up the build.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>