### PR TITLE
storage: add block-devices alias support

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -247,21 +247,6 @@ func applyHooks(name string, vars map[string]string, hooks []*model.InstallHook)
 	return nil
 }
 
-func expandHookVariable(vars map[string]string, cmd string) string {
-	// iterate over available variables
-	for k, v := range vars {
-		// tries to replace both ${var} and $var forms
-		for _, rep := range []string{fmt.Sprintf("$%s", k), fmt.Sprintf("${%s}", k)} {
-			if strings.Contains(cmd, rep) {
-				return strings.Replace(cmd, rep, v, -1)
-			}
-		}
-	}
-
-	// if no variables are expanded return the original cmd string
-	return cmd
-}
-
 func runInstallHook(vars map[string]string, hook *model.InstallHook) error {
 	args := []string{}
 	vars["chrooted"] = "0"
@@ -271,7 +256,7 @@ func runInstallHook(vars map[string]string, hook *model.InstallHook) error {
 		vars["chrooted"] = "1"
 	}
 
-	exec := expandHookVariable(vars, hook.Cmd)
+	exec := utils.ExpandVariables(vars, hook.Cmd)
 	args = append(args, []string{"bash", "-c", exec}...)
 
 	if err := cmd.RunAndLogWithEnv(vars, args...); err != nil {

--- a/model/model.go
+++ b/model/model.go
@@ -72,8 +72,9 @@ type InstallHook struct {
 //   {name: "alias", file: "/dev/nvme0n1"}
 // ]
 type StorageAlias struct {
-	Name string `yaml:"name,omitempty,flow"`
-	File string `yaml:"file,omitempty,flow"`
+	Name       string `yaml:"name,omitempty,flow"`
+	File       string `yaml:"file,omitempty,flow"`
+	DeviceFile bool
 }
 
 // AddExtraKernelArguments adds a set of custom extra kernel arguments to be added to the
@@ -264,6 +265,7 @@ func LoadFile(path string) (*SystemInstall, error) {
 				continue
 			}
 
+			curr.DeviceFile = true
 			alias[curr.Name] = filepath.Base(curr.File)
 		}
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -42,6 +42,7 @@ func TestLoadFile(t *testing.T) {
 		{"valid-minimal.yaml", true},
 		{"valid-with-version.yaml", true},
 		{"block-devices-alias.yaml", true},
+		{"block-device-image.yaml", true},
 	}
 
 	for _, curr := range tests {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -43,6 +43,7 @@ func TestLoadFile(t *testing.T) {
 		{"valid-with-version.yaml", true},
 		{"block-devices-alias.yaml", true},
 		{"block-device-image.yaml", true},
+		{"valid-with-pre-post-hooks.yaml", true},
 	}
 
 	for _, curr := range tests {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -458,7 +458,7 @@ func listBlockDevices(userDefined []*BlockDevice) ([]*BlockDevice, error) {
 
 	if err = utils.VerifyRootUser(); err == nil {
 		for _, bd := range bds {
-			if err = bd.partProbe(); err != nil {
+			if err = bd.PartProbe(); err != nil {
 				return nil, err
 			}
 		}
@@ -971,7 +971,8 @@ func NewStandardPartitions(disk *BlockDevice) {
 	})
 }
 
-func (bd *BlockDevice) partProbe() error {
+// PartProbe runs partprobe against the block device's file
+func (bd *BlockDevice) PartProbe() error {
 	args := []string{
 		"partprobe",
 		bd.GetDeviceFile(),
@@ -982,4 +983,19 @@ func (bd *BlockDevice) partProbe() error {
 	}
 
 	return nil
+}
+
+// DiskSize given a BlockDevice sum's up its size and children sizes
+func (bd *BlockDevice) DiskSize() uint64 {
+	size := bd.Size
+
+	for _, ch := range bd.Children {
+		if len(ch.Children) > 0 {
+			size += ch.DiskSize()
+		} else {
+			size += ch.Size
+		}
+	}
+
+	return size
 }

--- a/tests/block-device-image.yaml
+++ b/tests/block-device-image.yaml
@@ -1,0 +1,30 @@
+#clear-linux-config
+block-devices: [
+   {name: "target", file: "target.img"}
+]
+
+targetMedia:
+- name: ${target}
+  size: "30752636928"
+  type: disk
+  children:
+  - name: ${target}1
+    fstype: vfat
+    mountpoint: /boot
+    size: "157286400"
+    type: part
+  - name: ${target}2
+    fstype: swap
+    size: "2147483648"
+    type: part
+  - name: ${target}3
+    fstype: ext4
+    mountpoint: /
+    size: "28447866880"
+    type: part
+
+bundles: [os-core, os-core-update]
+telemetry: false
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native

--- a/tests/block-devices-alias.yaml
+++ b/tests/block-devices-alias.yaml
@@ -1,0 +1,31 @@
+#clear-linux-config
+block-devices: [
+   {name: "target", file: "/dev/sda"},
+   {name: "unused", file: "/dev/null"}
+]
+
+targetMedia:
+- name: ${target}
+  size: "30752636928"
+  type: disk
+  children:
+  - name: ${target}1
+    fstype: vfat
+    mountpoint: /boot
+    size: "157286400"
+    type: part
+  - name: ${target}2
+    fstype: swap
+    size: "2147483648"
+    type: part
+  - name: ${target}3
+    fstype: ext4
+    mountpoint: /
+    size: "28447866880"
+    type: part
+
+bundles: [os-core, os-core-update]
+telemetry: false
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native

--- a/tests/valid-minimal.yaml
+++ b/tests/valid-minimal.yaml
@@ -23,14 +23,3 @@ telemetry: false
 keyboard: us
 language: en_US.UTF-8
 kernel: kernel-native
-pre-install: [
-   {cmd: 'echo "running pre-install hook. dir: $chrootDir, chroot? $chrooted"'}
-]
-post-install: [
-   {cmd: "tests/post-install-sample.sh ${chrooted}"},
-   {chroot: true, cmd: 'echo "running: dir: $chrootDir, chrooted? $chrooted"'}
-]
-# post install commands will have a set of pre-defined variables expanded
-# currently supported variables are:
-#    chrootDir - the installation chrootDir (where the target system's media is mounted)
-#    chrooted  - set to 1 if the command is executed chrooted, 0 otherwise

--- a/tests/valid-with-pre-post-hooks.yaml
+++ b/tests/valid-with-pre-post-hooks.yaml
@@ -1,0 +1,36 @@
+#clear-linux-config
+targetMedia:
+- name: sda
+  size: "30752636928"
+  type: disk
+  children:
+  - name: sda1
+    fstype: vfat
+    mountpoint: /boot
+    size: "157286400"
+    type: part
+  - name: sda2
+    fstype: swap
+    size: "2147483648"
+    type: part
+  - name: sda3
+    fstype: ext4
+    mountpoint: /
+    size: "28447866880"
+    type: part
+bundles: [os-core, os-core-update]
+telemetry: false
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native
+pre-install: [
+   {cmd: 'echo "running pre-install hook. dir: $chrootDir, chroot? $chrooted"'}
+]
+post-install: [
+   {cmd: "tests/post-install-sample.sh ${chrooted}"},
+   {chroot: true, cmd: 'echo "running: dir: $chrootDir, chrooted? $chrooted"'}
+]
+# post install commands will have a set of pre-defined variables expanded
+# currently supported variables are:
+#    chrootDir - the installation chrootDir (where the target system's media is mounted)
+#    chrooted  - set to 1 if the command is executed chrooted, 0 otherwise

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,12 +5,14 @@
 package utils
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -151,4 +153,21 @@ func IsStdoutTTY() bool {
 	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, syscall.TCGETS, ptr, 0, 0, 0)
 
 	return err == 0
+}
+
+// ExpandVariables iterates over vars map and replace all the ocorrences of ${var} or
+// $var in the str string
+func ExpandVariables(vars map[string]string, str string) string {
+	// iterate over available variables
+	for k, v := range vars {
+		// tries to replace both ${var} and $var forms
+		for _, rep := range []string{fmt.Sprintf("$%s", k), fmt.Sprintf("${%s}", k)} {
+			if strings.Contains(str, rep) {
+				return strings.Replace(str, rep, v, -1)
+			}
+		}
+	}
+
+	// if no variables are expanded return the original string
+	return str
 }


### PR DESCRIPTION
**This PR includes:**
- block device alias support - users may declare alias and use'em throughout the target media configuration;
- add image support - this is a special alias block device configuration, the controller will setup the loop device and expand the block device's name accordingly
- a small testsuite shuffle