### PR TITLE
controller: simplify cleanup code

### DIFF
--- a/massinstall/massinstall.go
+++ b/massinstall/massinstall.go
@@ -132,18 +132,6 @@ func (mi *MassInstall) Run(md *model.SystemInstall, rootDir string) (bool, error
 		return false, instError
 	}
 
-	prg := progress.NewLoop("Saving the installation results")
-	if err := controller.SaveInstallResults(rootDir, md); err != nil {
-		log.ErrorError(err)
-	}
-	prg.Success()
-
-	prg = progress.NewLoop("Cleaning up install environment")
-	if err := controller.Cleanup(rootDir, true); err != nil {
-		log.ErrorError(err)
-	}
-	prg.Success()
-
 	var reboot bool
 
 	if instError != nil {

--- a/tui/install.go
+++ b/tui/install.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/clearlinux/clr-installer/controller"
-	"github.com/clearlinux/clr-installer/log"
 	"github.com/clearlinux/clr-installer/progress"
 
 	"github.com/VladimirMarkelov/clui"
@@ -95,18 +94,6 @@ func (page *InstallPage) Activate() {
 			page.Panic(err)
 			return // In a panic state, do not continue
 		}
-
-		prg := progress.NewLoop("Saving the installation results")
-		if err := controller.SaveInstallResults(page.tui.rootDir, page.getModel()); err != nil {
-			log.ErrorError(err)
-		}
-		prg.Success()
-
-		prg = progress.NewLoop("Cleaning up install environment")
-		if err := controller.Cleanup(page.tui.rootDir, true); err != nil {
-			log.ErrorError(err)
-		}
-		prg.Success()
 
 		page.prgLabel.SetTitle("Installation complete")
 		page.rebootBtn.SetEnabled(true)


### PR DESCRIPTION
Simplify the cleanup code and move the SaveInstallResults() call to
the controller code, removing this knowledge from the front end
implementations.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>