### PR TITLE
args: rename --mirror to --swupd-mirror

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -114,8 +114,8 @@ func (args *Args) setCommandLineArgs() (err error) {
 		&args.ConfigFile, "config", "c", args.ConfigFile, "Installation configuration file",
 	)
 
-	flag.StringVarP(
-		&args.SwupdMirror, "mirror", "m", args.SwupdMirror, "Swupd Installation mirror URL",
+	flag.StringVar(
+		&args.SwupdMirror, "swupd-mirror", args.SwupdMirror, "Swupd Installation mirror URL",
 	)
 
 	flag.BoolVar(


### PR DESCRIPTION
Preventing future confusions (when we implement dnf support) rename
the --mirror argument to --swupd-mirror and start creating a namespace
for the arguments.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>