### PR TITLE
Clean Up all temporary files and directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,13 @@ check-coverage: gopath
 	@$(top_srcdir)/.gopath/bin/local-travis
 
 check: gopath
+	# Ensure no temp files are left behind
+	$(eval BEFORESHA = $(shell ls -art /tmp | sha512sum))
 	go test -cover ${GO_PACKAGE_PREFIX}/...
+	@if [ "$(BEFORESHA)" != "$$(ls -art /tmp | sha512sum)" ] ; then \
+		echo "Test Failed: Temporary directory may not be clean!"; \
+		/bin/false ; \
+	fi \
 
 check-clean: gopath
 	go clean -testcache

--- a/args/args.go
+++ b/args/args.go
@@ -41,6 +41,7 @@ type Args struct {
 	RebootSet       bool
 	LogFile         string
 	ConfigFile      string
+	CfDownloaded    bool
 	SwupdMirror     string
 	Telemetry       bool
 	TelemetrySet    bool
@@ -82,6 +83,7 @@ func (args *Args) setKernelArgs() (err error) {
 		}
 
 		args.ConfigFile = ffile
+		args.CfDownloaded = true
 	}
 
 	return nil

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -150,6 +150,7 @@ func main() {
 	if err != nil {
 		fatal(err)
 	}
+	defer func() { _ = os.RemoveAll(rootDir) }()
 
 	var md *model.SystemInstall
 	cf := options.ConfigFile
@@ -158,6 +159,9 @@ func main() {
 		if cf, err = conf.LookupDefaultConfig(); err != nil {
 			fatal(err)
 		}
+	}
+	if options.CfDownloaded {
+		defer func() { _ = os.Remove(cf) }()
 	}
 
 	log.Debug("Loading config file: %s", cf)

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -109,6 +109,7 @@ func FetchRemoteConfigFile(url string) (string, error) {
 
 	_, err = io.Copy(out, resp.Body)
 	if err != nil {
+		defer func() { _ = os.Remove(out.Name()) }()
 		return "", err
 	}
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -67,7 +67,10 @@ func TestTag(t *testing.T) {
 	}
 
 	fh := setLog(t)
-	defer func() { _ = fh.Close() }()
+	defer func() {
+		_ = fh.Close()
+		_ = os.Remove(fh.Name())
+	}()
 
 	if err := SetLogLevel(LogLevelDebug); err != nil {
 		t.Fatal("Should not fail with a valid level")
@@ -90,7 +93,10 @@ func TestTag(t *testing.T) {
 
 func TestErrorError(t *testing.T) {
 	fh := setLog(t)
-	defer func() { _ = fh.Close() }()
+	defer func() {
+		_ = fh.Close()
+		_ = os.Remove(fh.Name())
+	}()
 
 	ErrorError(fmt.Errorf("testing log with error"))
 
@@ -112,7 +118,10 @@ func TestLogLevel(t *testing.T) {
 	}
 
 	fh := setLog(t)
-	defer func() { _ = fh.Close() }()
+	defer func() {
+		_ = fh.Close()
+		_ = os.Remove(fh.Name())
+	}()
 
 	for _, curr := range tests {
 		if err := SetLogLevel(curr.mutedLevel); err != nil {
@@ -164,7 +173,10 @@ func TestInvalidLogLevel(t *testing.T) {
 
 func TestLogTraceableError(t *testing.T) {
 	fh := setLog(t)
-	defer func() { _ = fh.Close() }()
+	defer func() {
+		_ = fh.Close()
+		_ = os.Remove(fh.Name())
+	}()
 
 	ErrorError(errors.Errorf("Traceable error"))
 
@@ -175,7 +187,10 @@ func TestLogTraceableError(t *testing.T) {
 
 func TestLogOut(t *testing.T) {
 	fh := setLog(t)
-	defer func() { _ = fh.Close() }()
+	defer func() {
+		_ = fh.Close()
+		_ = os.Remove(fh.Name())
+	}()
 	Out("command output")
 
 	if !strings.Contains(readLog(t).String(), "[OUT]") {

--- a/scripts/mk-installer-image.sh
+++ b/scripts/mk-installer-image.sh
@@ -179,7 +179,8 @@ sudo sed -i -e '/server=/s/clr.telemetry.intel.com/localhost/' \
     ${TEMP}/etc/telemetrics/telemetrics.conf
 popd
 
-sudo umount $TEMP
+sudo umount ${TEMP}
 $(${CLEANUPCMD})
+sudo /bin/rm -rf ${TEMP}
 
 exit 0


### PR DESCRIPTION
Ensure both the main code and test clean up after themselves.

Testing for changes in the /tmp directory done in the Makefile
to ensure the testing is done outside of the code itself.