### PR TITLE
tui: support loop device

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -407,7 +407,7 @@ func HumanReadableSize(size uint64) (string, error) {
 // FreeSpace returns the block device available/free space considering the currently
 // configured partition table
 func (bd *BlockDevice) FreeSpace() (uint64, error) {
-	if bd.Type != BlockDeviceTypeDisk {
+	if !utils.IntSliceContains([]int{BlockDeviceTypeDisk, BlockDeviceTypeLoop}, int(bd.Type)) {
 		return 0, errors.Errorf("FreeSpace() must only be called with a disk block device")
 	}
 

--- a/tui/disk_config.go
+++ b/tui/disk_config.go
@@ -186,7 +186,7 @@ func (page *DiskConfigPage) Activate() {
 		for _, curr := range page.blockDevices {
 			if status := curr.GetConfiguredStatus(); status != storage.ConfiguredNone {
 				// A disk beside the active is configured
-				if page.activeSerial != curr.Serial {
+				if page.activeSerial != curr.Serial && page.lastAutoButton != nil {
 					// Disable Auto Partitioning
 					page.lastAutoButton.SetEnabled(false)
 				}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -139,6 +139,16 @@ func StringSliceContains(sl []string, str string) bool {
 	return false
 }
 
+// IntSliceContains returns true if is contains value, returns false otherwise
+func IntSliceContains(is []int, value int) bool {
+	for _, curr := range is {
+		if curr == value {
+			return true
+		}
+	}
+	return false
+}
+
 // IsCheckCoverage returns true if CHECK_COVERAGE variable is set
 func IsCheckCoverage() bool {
 	return os.Getenv("CHECK_COVERAGE") != ""


### PR DESCRIPTION
Loop devices are valid then don't exclude it when reading block device's
configuration, also make sure tui reacts properly.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>

Fixes Issue: #95