### PR TITLE
Do not change default for Escape-Cancel

### DIFF
--- a/tui/autoupdate.go
+++ b/tui/autoupdate.go
@@ -65,7 +65,7 @@ func (aup *AutoUpdatePage) DeActivate() {
 
 	if aup.action == ActionConfirmButton {
 		model.AutoUpdate = true
-	} else {
+	} else if aup.action == ActionBackButton {
 		model.AutoUpdate = false
 	}
 }

--- a/tui/telemetry.go
+++ b/tui/telemetry.go
@@ -83,7 +83,14 @@ func newTelemetryPage(tui *Tui) (Page, error) {
 
 // DeActivate sets the model value and adjusts the "confirm" flag for this page
 func (tp *TelemetryPage) DeActivate() {
-	tp.getModel().EnableTelemetry(tp.action == ActionConfirmButton)
+	model := tp.getModel()
+
+	if tp.action == ActionConfirmButton {
+		model.EnableTelemetry(true)
+	} else if tp.action == ActionBackButton {
+		model.EnableTelemetry(false)
+	}
+
 	tp.SetDone(true)
 }
 


### PR DESCRIPTION
Two of the Enable/Disable configuration options were assuming Confirm was enabled; otherwise, disable. Escape to cancel should not change the default answer.

