### PR TITLE
Fix: Pipe Commands Hang

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -92,7 +92,9 @@ func run(sw func(cmd *exec.Cmd) error, writer io.Writer, env map[string]string, 
 
 	cmd.Stdout = writer
 	cmd.Stderr = writer
-	cmd.Stdin = os.Stdin
+	if cmd.Stdin == nil {
+		cmd.Stdin = os.Stdin
+	}
 
 	for k, v := range env {
 		cmd.Args = append(cmd.Args, fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION
Commands run through PipeRunAndLog would hang waiting for standard input.
We were overwriting the defined stdin input stream.