### PR TITLE
tui: Fix default Language

### DIFF
--- a/tui/language.go
+++ b/tui/language.go
@@ -89,12 +89,14 @@ func newLanguagePage(tui *Tui) (Page, error) {
 		}
 	})
 
+	modelLanguage := page.getModel().Language
 	defLanguage := 0
 	for idx, curr := range page.avLanguages {
 		page.langListBox.AddItem(curr.String())
 
-		if curr.Equals(page.getModel().Language) {
+		if curr.Equals(modelLanguage) {
 			defLanguage = idx
+			modelLanguage.Tag = curr.Tag
 		}
 	}
 


### PR DESCRIPTION
Fixes #46

The language code is what is stored in the configuration file and is unmarshalled into the model, the language Tag is left uninitialized. When we find the language code match on initialization, set the language Tag correctly for display in the TUI.