### PR TITLE
image: fix image overwrite

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -296,7 +296,7 @@ func LoadFile(path string, options args.Args) (*SystemInstall, error) {
 				continue
 			}
 
-			if (fi != nil && fi.Mode()&os.ModeDevice == 1) && !inTestAlias {
+			if (fi != nil && fi.Mode()&os.ModeDevice == 0) && !inTestAlias {
 				continue
 			}
 


### PR DESCRIPTION
We're failing to detect if the the target system block device is an
image file or a device file, with that we fail to overwrite the image
assuming the target file is /dev/<img-file> instead of setting the
loop device up and using it.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>