### PR TITLE
installer image: set timeout

### DIFF
--- a/scripts/installer-image-post.sh
+++ b/scripts/installer-image-post.sh
@@ -17,4 +17,6 @@ sed -i -e '/server=/s/clr.telemetry.intel.com/localhost/' \
     -e '/record_retention_enabled/s/=false/=true/' \
     $1/etc/telemetrics/telemetrics.conf
 
+echo "timeout 5" >> $1/boot/loader/loader.conf
+
 make clean


### PR DESCRIPTION
This patch sets the systemd-boot's timeout to 5 so the user may have
the opportunity to change the kernel arguments.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>