### PR TITLE
Change default log level to remove debug data by default

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -155,7 +155,7 @@ func (args *Args) setCommandLineArgs() (err error) {
 		&args.LogLevel,
 		"log-level",
 		"l",
-		log.LogLevelDebug,
+		args.LogLevel,
 		fmt.Sprintf("%d (debug), %d (info), %d (warning), %d (error)",
 			log.LogLevelDebug, log.LogLevelInfo, log.LogLevelWarning, log.LogLevelError),
 	)
@@ -231,6 +231,9 @@ func (args *Args) setCommandLineArgs() (err error) {
 // and read any options set on the kernel command line from boot-time
 // setting the results into the Args member variables.
 func (args *Args) ParseArgs() (err error) {
+	// Set the default log level
+	args.LogLevel = log.LogLevelInfo
+
 	err = args.setKernelArgs()
 	if err != nil {
 		return err

--- a/args/args.go
+++ b/args/args.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/clearlinux/clr-installer/conf"
@@ -27,6 +28,7 @@ import (
 const (
 	kernelCmdlineConf = "clri.descriptor"
 	kernelCmdlineDemo = "clri.demo"
+	kernelCmdlineLog  = "clri.loglevel"
 	logFileEnvironVar = "CLR_INSTALLER_LOG_FILE"
 )
 
@@ -70,10 +72,18 @@ func (args *Args) setKernelArgs() (err error) {
 
 	// Parse the kernel command for relevant installer options
 	for _, curr := range strings.Split(kernelCmd, " ") {
+		curr = strings.TrimSpace(curr)
 		if strings.HasPrefix(curr, kernelCmdlineConf+"=") {
 			url = strings.Split(curr, "=")[1]
 		} else if strings.HasPrefix(curr, kernelCmdlineDemo) {
 			args.DemoMode = true
+		} else if strings.HasPrefix(curr, kernelCmdlineLog) {
+			logLevelString := strings.Split(curr, "=")[1]
+			if logLevel, _ := strconv.Atoi(logLevelString); err != nil {
+				log.Warning("Ignoring invalid kernel parameter %s='%s'", kernelCmdlineLog, logLevelString)
+			} else {
+				args.LogLevel = logLevel
+			}
 		}
 	}
 

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -352,8 +352,8 @@ func TestKernelAndCommandlineAllArgs(t *testing.T) {
 	if testArgs.PamSalt != "" {
 		t.Errorf("Command Line 'genpwd' is not defaulted to ''")
 	}
-	if testArgs.LogLevel != log.LogLevelDebug {
-		t.Errorf("Command Line 'log-level' is not defaulted to '%d'", log.LogLevelDebug)
+	if testArgs.LogLevel != log.LogLevelInfo {
+		t.Errorf("Command Line 'log-level' is not defaulted to '%d'", log.LogLevelInfo)
 	}
 	if testArgs.LogFile == "" {
 		t.Errorf("Command Line 'log-file' is NOT set to value")

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -188,7 +188,7 @@ func main() {
 		if err != nil {
 			fatal(err)
 		} else {
-			log.Debug("Using Swupd Mirror value: %q", url)
+			log.Info("Using Swupd Mirror value: %q", url)
 		}
 	}
 

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -109,14 +109,22 @@ func main() {
 	// Make the Version of the program visible to telemetry
 	telemetry.ProgVersion = model.Version
 
-	if err := log.SetLogLevel(options.LogLevel); err != nil {
+	f, err := log.SetOutputFilename(options.LogFile)
+	if err != nil {
 		fatal(err)
 	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	log.SetLogLevel(options.LogLevel)
+
+	log.Info(path.Base(os.Args[0]) + ": " + model.Version)
 
 	if options.PamSalt != "" {
-		hashed, err := crypt.Crypt(options.PamSalt)
+		hashed, errHash := crypt.Crypt(options.PamSalt)
 		if err != nil {
-			panic(err)
+			panic(errHash)
 		}
 
 		fmt.Println(hashed)
@@ -127,15 +135,6 @@ func main() {
 		fmt.Println(path.Base(os.Args[0]) + ": " + model.Version)
 		return
 	}
-
-	f, err := log.SetOutputFilename(options.LogFile)
-	if err != nil {
-		fatal(err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-	log.Info(path.Base(os.Args[0]) + ": " + model.Version)
 
 	initFrontendList()
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -31,7 +31,7 @@ func (rl runLogger) Write(p []byte) (n int, err error) {
 			continue
 		}
 
-		log.Out(curr)
+		log.Debug(curr)
 	}
 	return len(p), nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -14,17 +14,21 @@ import (
 )
 
 const (
-	// LogLevelDebug specified the log level as: DEBUG
-	LogLevelDebug = 1
-
-	// LogLevelInfo specified the log level as: INFO
-	LogLevelInfo = 2
+	// LogLevelError specified the log level as: ERROR
+	LogLevelError = 1
 
 	// LogLevelWarning specified the log level as: WARNING
-	LogLevelWarning = 3
+	LogLevelWarning = 2
 
-	// LogLevelError specified the log level as: ERROR
-	LogLevelError = 4
+	// LogLevelInfo specified the log level as: INFO
+	LogLevelInfo = 3
+
+	// LogLevelDebug specified the log level as: DEBUG
+	LogLevelDebug = 4
+
+	// LogLevelVerbose specified the log level as: VERBOSE
+	// This is the same as Debug, but without the repeat filtering
+	LogLevelVerbose = 5
 )
 
 var (
@@ -37,19 +41,20 @@ var (
 )
 
 func init() {
-	levelMap[LogLevelDebug] = "LogLevelDebug"
-	levelMap[LogLevelInfo] = "LogLevelInfo"
-	levelMap[LogLevelWarning] = "LogLevelWarning"
 	levelMap[LogLevelError] = "LogLevelError"
+	levelMap[LogLevelWarning] = "LogLevelWarning"
+	levelMap[LogLevelInfo] = "LogLevelInfo"
+	levelMap[LogLevelDebug] = "LogLevelDebug"
+	levelMap[LogLevelVerbose] = "LogLevelVerbose"
 }
 
 // SetLogLevel sets the default log level to l
 func SetLogLevel(l int) {
-	if l < LogLevelDebug {
-		level = LogLevelDebug
-		logTag("WRN", "Log Level '%d' too low, forcing to %s (%d)", l, levelMap[level], level)
-	} else if l > LogLevelError {
+	if l < LogLevelError {
 		level = LogLevelError
+		logTag("WRN", "Log Level '%d' too low, forcing to %s (%d)", l, levelMap[level], level)
+	} else if l > LogLevelVerbose {
+		level = LogLevelVerbose
 		logTag("WRN", "Log Level '%d' too high, forcing to %s (%d)", l, levelMap[level], level)
 	} else {
 		level = l
@@ -124,6 +129,11 @@ func logTag(tag string, format string, a ...interface{}) {
 	f := fmt.Sprintf("[%s] %s\n", tag, format)
 	output := fmt.Sprintf(f, a...)
 
+	if level >= LogLevelVerbose {
+		log.Printf(output)
+		return
+	}
+
 	if output != lineLast {
 		// output the previous repeated line
 		if lineCount > 0 {
@@ -147,7 +157,7 @@ func logTag(tag string, format string, a ...interface{}) {
 
 // Debug prints a debug log entry with DBG tag
 func Debug(format string, a ...interface{}) {
-	if level > LogLevelDebug {
+	if level < LogLevelDebug {
 		return
 	}
 
@@ -174,7 +184,7 @@ func ErrorError(err error) {
 
 // Info prints an info log entry with INF tag
 func Info(format string, a ...interface{}) {
-	if level > LogLevelInfo {
+	if level < LogLevelInfo {
 		return
 	}
 
@@ -183,7 +193,7 @@ func Info(format string, a ...interface{}) {
 
 // Warning prints an warning log entry with WRN tag
 func Warning(format string, a ...interface{}) {
-	if level > LogLevelWarning {
+	if level < LogLevelWarning {
 		return
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -31,6 +31,9 @@ var (
 	level      = LogLevelInfo
 	levelMap   = map[int]string{}
 	filehandle *os.File
+
+	lineLast  string
+	lineCount int
 )
 
 func init() {
@@ -115,8 +118,27 @@ func LevelStr(level int) (string, error) {
 
 func logTag(tag string, format string, a ...interface{}) {
 	f := fmt.Sprintf("[%s] %s\n", tag, format)
-	str := fmt.Sprintf(f, a...)
-	log.Printf(str)
+	output := fmt.Sprintf(f, a...)
+
+	if output != lineLast {
+		// output the previous repeated line
+		if lineCount > 0 {
+			plural := ""
+			if lineCount > 1 {
+				plural = "s"
+			}
+
+			repeat := fmt.Sprintf("[%s] [Previous line repeated %d time%s]\n", tag, lineCount, plural)
+			log.Printf(repeat)
+		}
+
+		log.Printf(output)
+
+		lineLast = output
+		lineCount = 0
+	} else { // Repeated line
+		lineCount++
+	}
 }
 
 // Debug prints a debug log entry with DBG tag

--- a/log/log.go
+++ b/log/log.go
@@ -44,13 +44,17 @@ func init() {
 }
 
 // SetLogLevel sets the default log level to l
-func SetLogLevel(l int) error {
-	if l < LogLevelDebug || l > LogLevelError {
-		return errors.Errorf("Invalid log level: %d", l)
+func SetLogLevel(l int) {
+	if l < LogLevelDebug {
+		level = LogLevelDebug
+		logTag("WRN", "Log Level '%d' too low, forcing to %s (%d)", l, levelMap[level], level)
+	} else if l > LogLevelError {
+		level = LogLevelError
+		logTag("WRN", "Log Level '%d' too high, forcing to %s (%d)", l, levelMap[level], level)
+	} else {
+		level = l
+		Debug("Log Level set to %s (%d)", levelMap[level], l)
 	}
-
-	level = l
-	return nil
 }
 
 // SetOutputFilename ... sets the default log output to filename instead of stdout/stderr

--- a/log/log.go
+++ b/log/log.go
@@ -155,12 +155,6 @@ func Info(format string, a ...interface{}) {
 	logTag("INF", format, a...)
 }
 
-// Out is an special logging function, it's used for command output
-// and has no log level restrictions
-func Out(format string, a ...interface{}) {
-	logTag("OUT", format, a...)
-}
-
 // Warning prints an warning log entry with WRN tag
 func Warning(format string, a ...interface{}) {
 	if level > LogLevelWarning {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -72,9 +72,7 @@ func TestTag(t *testing.T) {
 		_ = os.Remove(fh.Name())
 	}()
 
-	if err := SetLogLevel(LogLevelDebug); err != nil {
-		t.Fatal("Should not fail with a valid level")
-	}
+	SetLogLevel(LogLevelDebug)
 
 	for _, curr := range tests {
 		curr.fc(curr.msg)
@@ -150,9 +148,7 @@ func TestLogLevel(t *testing.T) {
 	}()
 
 	for _, curr := range tests {
-		if err := SetLogLevel(curr.mutedLevel); err != nil {
-			t.Fatal("Should not fail with a valid log level")
-		}
+		SetLogLevel(curr.mutedLevel)
 		curr.fc(curr.msg)
 
 		if readLog(t).String() != "" {
@@ -192,9 +188,9 @@ func TestInvalidLogLevelStr(t *testing.T) {
 }
 
 func TestInvalidLogLevel(t *testing.T) {
-	if err := SetLogLevel(999); err == nil {
-		t.Fatal("Should fail with an invalid log level")
-	}
+	// Exercise the code paths for invalid, but it is not a fatal error
+	SetLogLevel(-1)
+	SetLogLevel(999)
 }
 
 func TestLogTraceableError(t *testing.T) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -185,19 +185,6 @@ func TestLogTraceableError(t *testing.T) {
 	}
 }
 
-func TestLogOut(t *testing.T) {
-	fh := setLog(t)
-	defer func() {
-		_ = fh.Close()
-		_ = os.Remove(fh.Name())
-	}()
-	Out("command output")
-
-	if !strings.Contains(readLog(t).String(), "[OUT]") {
-		t.Fatal("Out logs should contain the tag [OUT]")
-	}
-}
-
 func TestFailSeek(t *testing.T) {
 	err := ArchiveLogFile("archivefile")
 	if err == nil {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -91,6 +91,32 @@ func TestTag(t *testing.T) {
 	}
 }
 
+func TestRepeat(t *testing.T) {
+	fh := setLog(t)
+	defer func() {
+		_ = fh.Close()
+		_ = os.Remove(fh.Name())
+	}()
+
+	SetLogLevel(LogLevelDebug)
+
+	msg := "This is a log message"
+	Debug(msg)
+	Debug(msg)
+	Debug(msg)
+	Debug(msg)
+	Debug("Different")
+
+	str := readLog(t).String()
+	if str == "" {
+		t.Fatal("No log written to output")
+	}
+
+	if !strings.Contains(str, "repeated") {
+		t.Fatalf("Log generated an entries without the expected repeated message")
+	}
+}
+
 func TestErrorError(t *testing.T) {
 	fh := setLog(t)
 	defer func() {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -162,6 +162,7 @@ func TestLogLevelStr(t *testing.T) {
 		level int
 		str   string
 	}{
+		{LogLevelVerbose, "LogLevelVerbose"},
 		{LogLevelDebug, "LogLevelDebug"},
 		{LogLevelInfo, "LogLevelInfo"},
 		{LogLevelWarning, "LogLevelWarning"},

--- a/storage/ops.go
+++ b/storage/ops.go
@@ -138,7 +138,9 @@ func (bd *BlockDevice) WritePartitionTable() error {
 		return errors.Errorf("Type is partition, disk required")
 	}
 
-	prg := progress.NewLoop(fmt.Sprintf("Writing partition table to: %s", bd.Name))
+	mesg := fmt.Sprintf("Writing partition table to: %s", bd.Name)
+	prg := progress.NewLoop(mesg)
+	log.Info(mesg)
 	args := []string{
 		"parted",
 		"-s",
@@ -211,7 +213,9 @@ func (bd *BlockDevice) WritePartitionTable() error {
 	}
 	prg.Success()
 
-	prg = progress.MultiStep(len(guids), "Adjusting filesystem configurations")
+	msg := "Adjusting filesystem configurations"
+	prg = progress.MultiStep(len(guids), msg)
+	log.Info(msg)
 	cnt := 1
 	for idx, guid := range guids {
 		args = []string{

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -132,6 +132,8 @@ func (s *SoftwareUpdater) Update() error {
 		fmt.Sprintf("--statedir=%s", s.stateDir),
 	}
 
+	log.Info("Checking for swupd updates")
+
 	err := cmd.RunAndLog(args...)
 	if err != nil {
 		return errors.Wrap(err)

--- a/user/user.go
+++ b/user/user.go
@@ -15,6 +15,7 @@ import (
 	"github.com/clearlinux/clr-installer/conf"
 	"github.com/clearlinux/clr-installer/crypt"
 	"github.com/clearlinux/clr-installer/errors"
+	"github.com/clearlinux/clr-installer/log"
 	"github.com/clearlinux/clr-installer/progress"
 	"github.com/clearlinux/clr-installer/utils"
 )
@@ -154,6 +155,7 @@ func Apply(rootDir string, users []*User) error {
 	}
 
 	for _, usr := range users {
+		log.Info("Adding extra user '%s'", usr.Login)
 		if err := usr.apply(rootDir); err != nil {
 			prg.Failure()
 			return err


### PR DESCRIPTION
Changes proposed in this pull request:
- Changes default log level to Informational
- Remove the unfiltered logging, OUT and replace with Debug or Info
- Cache repeated output lines and report repetition count
- Do not abort on unknown log level
- Allow setting log level via kernel parameter -- likely need to debug installations in the wild


