### PR TITLE
args: add StubImage argument

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -58,6 +58,7 @@ type Args struct {
 	ArchiveSet      bool
 	DemoMode        bool
 	BlockDevices    []string
+	StubImage       bool
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -143,6 +144,10 @@ func (args *Args) setCommandLineArgs() (err error) {
 
 	flag.BoolVar(
 		&args.Telemetry, "telemetry", args.Telemetry, "Enable Telemetry",
+	)
+
+	flag.BoolVarP(
+		&args.StubImage, "stub-image", "S", args.StubImage, "Creates the filesystems only - dont perform an actual install",
 	)
 
 	flag.StringVar(

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -180,25 +180,28 @@ func main() {
 	if options.SwupdMirror != "" {
 		md.SwupdMirror = options.SwupdMirror
 	}
-	// Now validate the mirror from the config or command line
-	if md.SwupdMirror != "" {
-		var url string
-		url, err = swupd.SetHostMirror(md.SwupdMirror)
-		if err != nil {
-			fatal(err)
-		} else {
-			log.Info("Using Swupd Mirror value: %q", url)
-		}
-	}
 
-	if md.Keyboard != nil {
-		if err = keyboard.Apply(md.Keyboard); err != nil {
+	if !options.StubImage {
+		// Now validate the mirror from the config or command line
+		if md.SwupdMirror != "" {
+			var url string
+			url, err = swupd.SetHostMirror(md.SwupdMirror)
+			if err != nil {
+				fatal(err)
+			} else {
+				log.Info("Using Swupd Mirror value: %q", url)
+			}
+		}
+
+		if md.Keyboard != nil {
+			if err = keyboard.Apply(md.Keyboard); err != nil {
+				fatal(err)
+			}
+		}
+
+		if err = validateTelemetry(options, md); err != nil {
 			fatal(err)
 		}
-	}
-
-	if err = validateTelemetry(options, md); err != nil {
-		fatal(err)
 	}
 
 	installReboot := false


### PR DESCRIPTION
With this argument (either -S or --stub-image) we create the image
- if that's the case - and create the target file systems but don't
actually install content.

It's useful for pre-release validation where the content is generated
and dealt by the release tooling.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>