### PR TITLE
linter: add go build -race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,10 +142,11 @@ update-linters:
 	fi \
 
 PHONY += lint
-lint: build install-linters
+lint: build install-linters gopath
 	@echo "Running linters"
 	@rm -rf ${LOCAL_GOPATH}/src/${GO_PACKAGE_PREFIX}/vendor
 	@cp -af vendor/* ${LOCAL_GOPATH}/src/
+	@go build -race github.com/clearlinux/clr-installer/...
 	@gometalinter.v2 --deadline=10m --tests --vendor \
 	--exclude=vendor --disable-all \
 	--enable=misspell \


### PR DESCRIPTION
Fixes: #25 

Use the -race flag to detect/test for race conditions.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>