### PR TITLE
Fix the OS naming

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -34,10 +34,9 @@ const (
 	Title = `Enable Telemetry`
 	// Help is a predefined text to display on the Telemetry
 	// screen for interactive installations
-	Help = `Allow the Clear Linux OS for Intel Architecture to collect anonymous
-reports to improve system stability? These reports only relate to
-operating system details - no personally identifiable information is
-collected.
+	Help = `Allow the Clear Linux* OS to collect anonymous reports
+to improve system stability? These reports only relate to operating
+system details - no personally identifiable information is collected.
 
 See http://clearlinux.org/features/telemetry for more information.
 `

--- a/tui/common.go
+++ b/tui/common.go
@@ -382,7 +382,7 @@ func (page *BasePage) newWindow() {
 	// Default all the windows to borderless
 	clui.WindowManager().SetBorder(clui.BorderNone)
 	page.window = clui.AddWindow(x, y, WindowWidth, WindowHeight,
-		" [Clear Linux Installer ("+model.Version+")] ")
+		" [Clear Linux* OS Installer ("+model.Version+")] ")
 
 	page.window.SetTitleButtons(0)
 	page.window.SetSizable(false)


### PR DESCRIPTION
Update product name and text on the install screen