### PR TITLE
build: always create dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ endif
 install: build
 	@mkdir -p $(THEME_DIR)
 	@mkdir -p $(CONFIG_DIR)
+	@mkdir -p $(DESTDIR)/usr/bin
+	@mkdir -p $(SYSTEMD_DIR)
 	@install -m 755 $(top_srcdir)/.gopath/bin/clr-installer $(DESTDIR)/usr/bin/clr-installer
 	@install -m 644  $(top_srcdir)/themes/clr-installer.theme $(THEME_DIR)
 	@install -m 644  $(top_srcdir)/etc/clr-installer.yaml $(CONFIG_DIR)


### PR DESCRIPTION
If we're installing artifacts to a mock environment for example
the directories like /usr/bin may not exist.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>