### PR TITLE
swupd: use --keepcache with "update" command

### DIFF
--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -128,6 +128,7 @@ func (s *SoftwareUpdater) Update() error {
 	args := []string{
 		filepath.Join(s.rootDir, "/usr/bin/swupd"),
 		"update",
+		"--keepcache",
 		fmt.Sprintf("--path=%s", s.rootDir),
 		fmt.Sprintf("--statedir=%s", s.stateDir),
 	}


### PR DESCRIPTION
If we don't explicitly specify the --keepcache flag the previously
fetch content (specially when using --swupd-state flag) will be
cleaned up and all the content will be downloaded all over again.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>