### PR TITLE
Add bundle only when non-root users defined

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -250,6 +250,10 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		model.AddBundle(telemetry.RequiredBundle)
 	}
 
+	if len(model.Users) > 0 {
+		model.AddBundle(cuser.RequiredBundle)
+	}
+
 	if model.Timezone.Code != timezone.DefaultTimezone {
 		model.AddBundle(timezone.RequiredBundle)
 	}

--- a/etc/clr-installer.yaml
+++ b/etc/clr-installer.yaml
@@ -1,5 +1,5 @@
 ---
-bundles: [os-core, os-core-update, openssh-server, sudo]
+bundles: [os-core, os-core-update, openssh-server]
 keyboard: us
 language: en_US.UTF-8
 timezone: UTC

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -25,7 +25,7 @@ var (
 	CoreBundles = []string{
 		"os-core",
 		"os-core-update",
-		"sudo",
+		"openssh-server",
 	}
 )
 

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -63,8 +63,7 @@ func TestIsCoreBundle(t *testing.T) {
 		{"go-basic", false},
 		{"git", false},
 		{"games", false},
-		{"sudo", true},
-		{"os-core-update", true},
+		{"openssh-server", true},
 		{"os-core-update", true},
 	}
 

--- a/user/user.go
+++ b/user/user.go
@@ -38,6 +38,9 @@ const (
 	MaxLoginLength = 31
 	// MinPasswordLength is the shortest possible password
 	MinPasswordLength = 8
+
+	// RequiredBundle the bundle needed to enable non-root user accounts
+	RequiredBundle = "sysadmin-basic"
 )
 
 var (


### PR DESCRIPTION
Be consistent with ister_gui and only add the sysadmin-basic bundle when non-root users are added. Previous we were always adding the sudo bundle.


