### PR TITLE
storage: change default swap size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .gopath/
 bin/
 pkg/
+*.img

--- a/scripts/installer-image.yaml
+++ b/scripts/installer-image.yaml
@@ -8,7 +8,7 @@ block-devices: [
 
 targetMedia:
 - name: ${installer}
-  size: "2.4G"
+  size: "2.54G"
   type: disk
   children:
   - name: ${installer}1
@@ -18,7 +18,7 @@ targetMedia:
     type: part
   - name: ${installer}2
     fstype: swap
-    size: "120M"
+    size: "256M"
     type: part
   - name: ${installer}3
     fstype: ext4

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -944,7 +944,7 @@ func LargestFileSystemName() int {
 // default set of partitions required for an installation
 func NewStandardPartitions(disk *BlockDevice) {
 	bootSize := uint64(150 * (1 << 20))
-	swapSize := uint64(2 * (1 << 30))
+	swapSize := uint64(256 * (1 << 20))
 	rootSize := uint64(disk.Size - bootSize - swapSize)
 
 	disk.Children = nil


### PR DESCRIPTION
Adjust the swap partition size for the auto partition and the installer
image size.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>