### PR TITLE
New bundle name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@
 .gopath/
 bin/
 pkg/
-*.img

--- a/scripts/installer-image.yaml
+++ b/scripts/installer-image.yaml
@@ -26,7 +26,7 @@ targetMedia:
     size: "2187M"
     type: part
 
-bundles: [os-core, os-core-update, telemetrics, os-installer, openssh-server, tzdata, kbd, locales]
+bundles: [os-core, os-core-update, clr-installer]
 autoUpdate: false
 postArchive: false
 postReboot: false


### PR DESCRIPTION
Changes proposed in this pull request:
- Switch to the newly release clr-installer bundle
- Fix a bug where the generated image is removed right after creation


