### PR TITLE
swupd: add new flags

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -46,6 +46,9 @@ type Args struct {
 	CfDownloaded    bool
 	SwupdMirror     string
 	SwupdStateDir   string
+	SwupdFormat     string
+	SwupdContentURL string
+	SwupdVersionURL string
 	Telemetry       bool
 	TelemetrySet    bool
 	TelemetryURL    string
@@ -140,6 +143,20 @@ func (args *Args) setCommandLineArgs() (err error) {
 
 	flag.StringVar(
 		&args.SwupdStateDir, "swupd-state", args.SwupdMirror, "Swupd state-dir",
+	)
+
+	flag.StringVar(
+		&args.SwupdFormat, "swupd-format", args.SwupdFormat, "Swupd --format argument",
+	)
+
+	flag.StringVar(
+		&args.SwupdContentURL, "swupd-contenturl", args.SwupdContentURL,
+		"Swupd --contenturl argument",
+	)
+
+	flag.StringVar(
+		&args.SwupdVersionURL, "swupd-versionurl", args.SwupdVersionURL,
+		"Swupd --versionurl argument",
 	)
 
 	flag.BoolVar(

--- a/args/args.go
+++ b/args/args.go
@@ -38,30 +38,31 @@ var (
 
 // Args represents the user provided arguments
 type Args struct {
-	Version         bool
-	Reboot          bool
-	RebootSet       bool
-	LogFile         string
-	ConfigFile      string
-	CfDownloaded    bool
-	SwupdMirror     string
-	SwupdStateDir   string
-	SwupdFormat     string
-	SwupdContentURL string
-	SwupdVersionURL string
-	Telemetry       bool
-	TelemetrySet    bool
-	TelemetryURL    string
-	TelemetryTID    string
-	TelemetryPolicy string
-	PamSalt         string
-	LogLevel        int
-	ForceTUI        bool
-	Archive         bool
-	ArchiveSet      bool
-	DemoMode        bool
-	BlockDevices    []string
-	StubImage       bool
+	Version                 bool
+	Reboot                  bool
+	RebootSet               bool
+	LogFile                 string
+	ConfigFile              string
+	CfDownloaded            bool
+	SwupdMirror             string
+	SwupdStateDir           string
+	SwupdFormat             string
+	SwupdContentURL         string
+	SwupdVersionURL         string
+	SwupdSkipDiskSpaceCheck bool
+	Telemetry               bool
+	TelemetrySet            bool
+	TelemetryURL            string
+	TelemetryTID            string
+	TelemetryPolicy         string
+	PamSalt                 string
+	LogLevel                int
+	ForceTUI                bool
+	Archive                 bool
+	ArchiveSet              bool
+	DemoMode                bool
+	BlockDevices            []string
+	StubImage               bool
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -157,6 +158,11 @@ func (args *Args) setCommandLineArgs() (err error) {
 	flag.StringVar(
 		&args.SwupdVersionURL, "swupd-versionurl", args.SwupdVersionURL,
 		"Swupd --versionurl argument",
+	)
+
+	flag.BoolVar(
+		&args.SwupdSkipDiskSpaceCheck, "swupd-skip-diskspace-check",
+		true, "Swupd --skip-diskspace-check argument",
 	)
 
 	flag.BoolVar(

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -391,7 +391,7 @@ func runInstallHook(vars map[string]string, hook *model.InstallHook) error {
 // executed using the target swupd
 func contentInstall(rootDir string, version string, model *model.SystemInstall, options args.Args) (progress.Progress, error) {
 
-	sw := swupd.New(rootDir, options.SwupdStateDir)
+	sw := swupd.New(rootDir, options)
 
 	msg := "Installing the base system"
 	prg := progress.NewLoop(msg)

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -32,11 +32,12 @@ var (
 
 // SoftwareUpdater abstracts the swupd executable, environment and operations
 type SoftwareUpdater struct {
-	rootDir    string
-	stateDir   string
-	format     string
-	contentURL string
-	versionURL string
+	rootDir            string
+	stateDir           string
+	format             string
+	contentURL         string
+	versionURL         string
+	skipDiskSpaceCheck bool
 }
 
 // Bundle maps a map name and description with the actual checkbox
@@ -69,6 +70,7 @@ func New(rootDir string, options args.Args) *SoftwareUpdater {
 		options.SwupdFormat,
 		options.SwupdContentURL,
 		options.SwupdVersionURL,
+		options.SwupdSkipDiskSpaceCheck,
 	}
 }
 
@@ -134,7 +136,10 @@ func (s *SoftwareUpdater) Verify(version string, mirror string) error {
 	args = []string{
 		"swupd",
 		"bundle-add",
-		"--skip-diskspace-check",
+	}
+
+	if s.skipDiskSpaceCheck {
+		args = append(args, "--skip-diskspace-check")
 	}
 
 	args = s.setExtraFlags(args)
@@ -378,11 +383,19 @@ func (s *SoftwareUpdater) BundleAdd(bundle string) error {
 	args := []string{
 		filepath.Join(s.rootDir, "/usr/bin/swupd"),
 		"bundle-add",
-		"--skip-diskspace-check",
+	}
+
+	if s.skipDiskSpaceCheck {
+		args = append(args, "--skip-diskspace-check")
+	}
+
+	args = s.setExtraFlags(args)
+
+	args = append(args,
 		fmt.Sprintf("--path=%s", s.rootDir),
 		fmt.Sprintf("--statedir=%s", s.stateDir),
 		bundle,
-	}
+	)
 
 	err := cmd.RunAndLog(args...)
 	if err != nil {

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -7,6 +7,7 @@ package swupd
 import (
 	"testing"
 
+	"github.com/clearlinux/clr-installer/args"
 	"github.com/clearlinux/clr-installer/utils"
 )
 
@@ -84,13 +85,17 @@ func TestParseSwupdMirrorInvalid(t *testing.T) {
 }
 
 func TestNewWithState(t *testing.T) {
-	sw := New("/tmp/test", "/tmp/swupd-state")
+	options := args.Args{
+		SwupdStateDir: "/tmp/swupd-state",
+	}
+
+	sw := New("/tmp/test", options)
 
 	if sw.stateDir != "/tmp/swupd-state" {
 		t.Fatalf("stateDir should be set to /tmp/swupd-state")
 	}
 
-	sw = New("/tmp/test", "")
+	sw = New("/tmp/test", args.Args{})
 	if sw.stateDir != "/tmp/test/var/lib/swupd" {
 		t.Fatalf("stateDir should not be set to: %s", sw.stateDir)
 	}


### PR DESCRIPTION
Add the swupd's --format, --contenturl and --versionurl arguments.
These arguments are mapped with the --swupd prefix such as:
--swupd-format, --swupd-contenturl and --swupd-versionurl

And are used for constrained environments dealing with local installs,
specially with image generation in a network isolated environment.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>