### PR TITLE
Dump contents of coverage file on fail

### DIFF
--- a/tests/check-coverage.sh
+++ b/tests/check-coverage.sh
@@ -50,6 +50,7 @@ for key in ${!ccoverage[@]}; do
 done
 
 if [ $decreased -eq 1 ]; then
+    cat $tmp
     rm $tmp
     exit 1
 fi


### PR DESCRIPTION
Sometimes we get coverage reported as an empty string.
This can happen if there is a run time error during execution.

Now dump the contents of the newly generated coverage file
if there is a decrease.