### PR TITLE
images: reduce the swap partition

### DIFF
--- a/scripts/live-desktop.yaml
+++ b/scripts/live-desktop.yaml
@@ -18,12 +18,12 @@ targetMedia:
     type: part
   - name: ${bdevice}2
     fstype: swap
-    size: "256M"
+    size: "32M"
     type: part
   - name: ${bdevice}3
     fstype: ext4
     mountpoint: /
-    size: "7.59G"
+    size: "7.82G"
     type: part
 
 bundles: [


### PR DESCRIPTION
Reduce the swap partition to 32M with the live-desktop image.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>