### PR TITLE
build: make sure we let install command create dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,20 +48,15 @@ gopath:
 endif
 
 install: build
-	@mkdir -p $(THEME_DIR)
-	@mkdir -p $(CONFIG_DIR)
-	@mkdir -p $(DESTDIR)/usr/bin
-	@mkdir -p $(SYSTEMD_DIR)
-	@mkdir -p $(DESKTOP_DIR)
-	@install -m 755 $(top_srcdir)/.gopath/bin/clr-installer $(DESTDIR)/usr/bin/clr-installer
-	@install -m 755 $(top_srcdir)/scripts/clr-installer-desktop.sh $(DESTDIR)/usr/bin/clr-installer-desktop.sh
-	@install -m 644  $(top_srcdir)/themes/clr-installer.theme $(THEME_DIR)
-	@install -m 644  $(top_srcdir)/etc/clr-installer.yaml $(CONFIG_DIR)
-	@install -m 644  $(top_srcdir)/etc/bundles.json $(CONFIG_DIR)
-	@install -m 644  $(top_srcdir)/etc/kernels.json $(CONFIG_DIR)
-	@install -m 644  $(top_srcdir)/etc/clr-installer.desktop $(DESKTOP_DIR)
-	@install -m 644 $(top_srcdir)/etc/systemd/clr-installer.service $(SYSTEMD_DIR)
-	@install -m 644  $(top_srcdir)/etc/chpasswd $(CONFIG_DIR)
+	@install -D -m 755 $(top_srcdir)/.gopath/bin/clr-installer $(DESTDIR)/usr/bin/clr-installer
+	@install -D -m 755 $(top_srcdir)/scripts/clr-installer-desktop.sh $(DESTDIR)/usr/bin/clr-installer-desktop.sh
+	@install -D -m 644  $(top_srcdir)/themes/clr-installer.theme $(THEME_DIR)/clr-installer.theme
+	@install -D -m 644  $(top_srcdir)/etc/clr-installer.yaml $(CONFIG_DIR)/clr-installer.yaml
+	@install -D -m 644  $(top_srcdir)/etc/bundles.json $(CONFIG_DIR)/bundles.json
+	@install -D -m 644  $(top_srcdir)/etc/kernels.json $(CONFIG_DIR)/kernels.json
+	@install -D -m 644  $(top_srcdir)/etc/clr-installer.desktop $(DESKTOP_DIR)/clr-installer.desktop
+	@install -D -m 644 $(top_srcdir)/etc/systemd/clr-installer.service $(SYSTEMD_DIR)/clr-installer.service
+	@install -D -m 644  $(top_srcdir)/etc/chpasswd $(CONFIG_DIR)/chpasswd
 
 build-pkgs: build
 	@for pkg in `find -path ./vendor -prune -o -path ./.gopath -prune -o -name "*.go" \

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,18 @@ install: build
 	@install -D -m 644 $(top_srcdir)/etc/systemd/clr-installer.service $(SYSTEMD_DIR)/clr-installer.service
 	@install -D -m 644  $(top_srcdir)/etc/chpasswd $(CONFIG_DIR)/chpasswd
 
+uninstall:
+	@rm -f $(DESTDIR)/usr/bin/clr-installer
+	@rm -f $(DESTDIR)/usr/bin/clr-installer-desktop.sh
+	@rm -f $(THEME_DIR)/clr-installer.theme
+	@rm -f $(CONFIG_DIR)/clr-installer.yaml
+	@rm -f $(CONFIG_DIR)/bundles.json
+	@rm -f $(CONFIG_DIR)/kernels.json
+	@rm -f $(DESKTOP_DIR)/clr-installer.desktop
+	@rm -f $(SYSTEMD_DIR)/clr-installer.service
+	@rm -f $(CONFIG_DIR)/chpasswd
+	@rm -f $(DESTDIR)/var/lib/clr-installer/clr-installer.yaml
+
 build-pkgs: build
 	@for pkg in `find -path ./vendor -prune -o -path ./.gopath -prune -o -name "*.go" \
 	   -printf "%h\n" | sort -u | sed 's/\.\///g'`; do \


### PR DESCRIPTION
Use the -d argument for install command and let it deal with the
target directory creation.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>