### PR TITLE
swupd: use the host's swupd

### DIFF
--- a/scripts/builder.yaml
+++ b/scripts/builder.yaml
@@ -1,0 +1,46 @@
+#clear-linux-config
+
+# switch between aliases if you want to install to an actuall block device
+# i.e /dev/sda
+block-devices: [
+   {name: "bdevice", file: "clear-25570-builder.img"}
+]
+
+targetMedia:
+- name: ${bdevice}
+  type: disk
+  children:
+  - name: ${bdevice}1
+    fstype: vfat
+    mountpoint: /boot
+    size: "150M"
+    type: part
+  - name: ${bdevice}2
+    fstype: swap
+    size: "256M"
+    type: part
+  - name: ${bdevice}3
+    fstype: ext4
+    mountpoint: /
+    size: "16G"
+    type: part
+
+bundles: [
+   go-basic,
+   go-basic-dev,
+   mixer,
+   os-core,
+   os-core-dev,
+   os-core-update,
+   os-core-update-dev,
+   vim,
+  ]
+
+version: 25570
+autoUpdate: false
+postArchive: false
+postReboot: false
+telemetry: false
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -168,7 +168,7 @@ func (s *SoftwareUpdater) Verify(version string, mirror string) error {
 // Update executes the "swupd update" operation
 func (s *SoftwareUpdater) Update() error {
 	args := []string{
-		filepath.Join(s.rootDir, "/usr/bin/swupd"),
+		"swupd",
 		"update",
 		"--keepcache",
 		fmt.Sprintf("--path=%s", s.rootDir),
@@ -237,7 +237,7 @@ func GetHostMirror() (string, error) {
 // GetTargetMirror executes the "swupd mirror" to find the Target's mirror
 func (s *SoftwareUpdater) GetTargetMirror() (string, error) {
 	args := []string{
-		filepath.Join(s.rootDir, "/usr/bin/swupd"),
+		"swupd",
 		"mirror",
 		fmt.Sprintf("--path=%s", s.rootDir),
 	}
@@ -293,7 +293,7 @@ func SetHostMirror(url string) (string, error) {
 // verified as functional on the currently running Host
 func (s *SoftwareUpdater) SetTargetMirror(url string) (string, error) {
 	args := []string{
-		filepath.Join(s.rootDir, "/usr/bin/swupd"),
+		"swupd",
 		"mirror",
 		fmt.Sprintf("--path=%s", s.rootDir),
 		"--set",
@@ -381,7 +381,7 @@ func parseSwupdMirror(data []byte) (string, error) {
 // BundleAdd executes the "swupd bundle-add" operation for a single bundle
 func (s *SoftwareUpdater) BundleAdd(bundle string) error {
 	args := []string{
-		filepath.Join(s.rootDir, "/usr/bin/swupd"),
+		"swupd",
 		"bundle-add",
 	}
 


### PR DESCRIPTION
The clear linux OS release process assumes the images build should
be running the same swupd binary across all the build steps, this
patch makes sure we comply with that premise.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>