### PR TITLE
storage: don't unmarshal storage's serial number

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -994,7 +994,6 @@ func (bd *BlockDevice) MarshalYAML() (interface{}, error) {
 	bdm.MajorMinor = bd.MajorMinor
 	bdm.FsType = bd.FsType
 	bdm.UUID = bd.UUID
-	bdm.Serial = bd.Serial
 	bdm.MountPoint = bd.MountPoint
 	bdm.Label = bd.Label
 	bdm.Size = strconv.FormatUint(bd.Size, 10)


### PR DESCRIPTION
This information is actually useless for future references and could
also endup in the telemetry records. Since we have no good reason to
store it we don't want to marshal this data.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>