### PR TITLE
Rename Installer Image

### DIFF
--- a/scripts/developer-image-post.sh
+++ b/scripts/developer-image-post.sh
@@ -7,7 +7,7 @@ git clone . ${TEMP_INST}
 cd ${TEMP_INST}
 make install DESTDIR=${DESTDIR}
 
-scripts/installer-image-post.sh ${DESTDIR}
+scripts/installer-post.sh ${DESTDIR}
 
 cd ${SAVE_DIR}
 /bin/rm -rf ${TEMP_INST}

--- a/scripts/installer-post.sh
+++ b/scripts/installer-post.sh
@@ -15,6 +15,11 @@ sed -i -e '/server=/s/clr.telemetry.intel.com/localhost/' \
     -e '/record_retention_enabled/s/=false/=true/' \
     $1/etc/telemetrics/telemetrics.conf
 
+# Ensure telemetry is not enabled
+touch $1/etc/telemetrics/opt-out
+
+# Have the installer image wait 5 seconds before launch
+# Useful for users to change the boot command for debug
 echo "timeout 5" >> $1/boot/loader/loader.conf
 
 exit 0

--- a/scripts/installer.yaml
+++ b/scripts/installer.yaml
@@ -1,9 +1,14 @@
 #clear-linux-config
 
-# switch between aliases if you want to install to an actuall block device
+# installer.yaml
+#
+# This YAML file generates the basic TUI installer image for
+# Clear Linux OS
+
+# switch between aliases if you want to install to an actual block device
 # i.e /dev/sda
 block-devices: [
-   {name: "installer", file: "clear-installer.img"}
+   {name: "installer", file: "installer.img"}
 ]
 
 targetMedia:
@@ -39,5 +44,5 @@ kernel-arguments: {
 }
 
 post-install: [
-   {cmd: "scripts/installer-image-post.sh ${chrootDir}"}
+   {cmd: "scripts/installer-post.sh ${chrootDir}"}
 ]


### PR DESCRIPTION
To keep a consistent naming convention, rename installer image.

`[image-name].yaml -> clear-[VER]- [image-name].img.[compression ext]`