### PR TITLE
New Option to clean-up swupd state directory

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -47,6 +47,7 @@ type Args struct {
 	CryptPassFile           string
 	SwupdMirror             string
 	SwupdStateDir           string
+	SwupdStateClean         bool
 	SwupdFormat             string
 	SwupdContentURL         string
 	SwupdVersionURL         string
@@ -149,6 +150,11 @@ func (args *Args) setCommandLineArgs() (err error) {
 
 	flag.StringVar(
 		&args.SwupdStateDir, "swupd-state", args.SwupdMirror, "Swupd state-dir",
+	)
+
+	flag.BoolVar(
+		&args.SwupdStateClean, "swupd-clean",
+		false, "Clean Swupd state-dir content after install",
 	)
 
 	flag.StringVar(

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -504,6 +504,17 @@ func contentInstall(rootDir string, version string, model *model.SystemInstall, 
 	}
 	prg.Success()
 
+	// Clean-up State Directory content
+	if options.SwupdStateClean {
+		msg = "Cleaning Swupd state directory"
+		prg = progress.NewLoop(msg)
+		log.Info(msg)
+		if err = sw.CleanUpState(); err != nil {
+			log.ErrorError(err)
+		}
+		prg.Success()
+	}
+
 	return nil, nil
 }
 

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -426,4 +427,17 @@ func LoadBundleList() ([]*Bundle, error) {
 	}
 
 	return root.Bundles, nil
+}
+
+// CleanUpState removes the swupd state content directory
+func (s *SoftwareUpdater) CleanUpState() error {
+
+	log.Debug("Removing swupd state directory: %s", s.stateDir)
+
+	err := os.RemoveAll(s.stateDir)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fixes Issue: #215

Changes proposed in this pull request:
- Allow removing the state directory with new option '--swupd-clean'

