### PR TITLE
storage: Fix partition misalignment issue

### DIFF
--- a/storage/ops.go
+++ b/storage/ops.go
@@ -194,7 +194,7 @@ func (bd *BlockDevice) WritePartitionTable(legacyBios bool) error {
 		"--script",
 	}
 
-	var start uint64
+	var start uint64 = 1
 	bootPartition := -1
 	bootStyle := "boot"
 	guids := map[int]string{}


### PR DESCRIPTION
In the cases that 1MiB is the optimal alignment, specifying 0M as the
start position to the mkpart command will lead parted to create
misaligned partitions even when the option -a optimal is set. It could
cause dramatic performance degradation to I/O intensive workloads. Set
the start position to 1M so that the first partition can be properly
aligned and so are the other partitions.

Signed-off-by: Ming Chen <ming.a.chen@intel.com>

**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #

Changes proposed in this pull request:
-
-
-


