### PR TITLE
New telemetry defaults

### DIFF
--- a/hostname/hostname_test.go
+++ b/hostname/hostname_test.go
@@ -113,6 +113,10 @@ func TestFailedToCreateDir(t *testing.T) {
 	}
 
 	defer func() {
+		err = os.Chmod(rootDir, 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_ = os.RemoveAll(dir)
 	}()
 
@@ -142,6 +146,10 @@ func TestFailedToWrite(t *testing.T) {
 	}
 
 	defer func() {
+		err = os.Chmod(etcDir, 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_ = os.RemoveAll(dir)
 	}()
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -243,6 +243,10 @@ func TestFailedToArchiveUnwritableFile(t *testing.T) {
 	}
 
 	defer func() {
+		err = os.Chmod(rootDir, 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_ = os.RemoveAll(dir)
 	}()
 
@@ -272,6 +276,10 @@ func TestFailedToSetOutput(t *testing.T) {
 	}
 
 	defer func() {
+		err = os.Chmod(rootDir, 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_ = os.RemoveAll(dir)
 	}()
 

--- a/scripts/local-telemetry-post.sh
+++ b/scripts/local-telemetry-post.sh
@@ -8,7 +8,7 @@ cp $1/usr/share/defaults/telemetrics/telemetrics.conf \
    $1/etc/telemetrics/telemetrics.conf
 
 sed -i -e '/server=/s/clr.telemetry.intel.com/localhost/' \
-    -e '/spool_process_time/s/=900/=3600/' \
+    -e '/spool_process_time/s/=120/=300/' \
     -e '/record_retention_enabled/s/=false/=true/' \
     $1/etc/telemetrics/telemetrics.conf
 

--- a/tests/telemetrics.conf
+++ b/tests/telemetrics.conf
@@ -23,8 +23,8 @@ spool_dir=/var/spool/telemetry
 spool_max_size=5120
 
 # time in seconds for processing spool
-# Valid range: 120..3600. Values outside this range are clamped.
-spool_process_time=900
+# Valid range: 120..300. Values outside this range are clamped.
+spool_process_time=120
 
 # rate limit enabled - if this is set to false then all rate-limiting disabled.
 # It is possible to disable each rate-limit individually below.


### PR DESCRIPTION
Update the latest release telemetry configuration file
and update the post install hook with the new default
and the new maximum.