### PR TITLE
Chroot when enabling clr-installer service

### DIFF
--- a/scripts/developer-image-desktop-beta.yaml
+++ b/scripts/developer-image-desktop-beta.yaml
@@ -57,5 +57,6 @@ pre-install: [
 post-install: [
    {cmd: "scripts/live-image-post-update-version.py ${chrootDir}"},
    {cmd: "scripts/live-desktop-post-install.sh ${chrootDir}"},
-   {cmd: "scripts/developer-image-post.sh ${chrootDir}"}
+   {cmd: "scripts/developer-image-post.sh ${chrootDir}"},
+   {cmd: "systemctl enable clr-installer", chroot: true}
 ]

--- a/scripts/developer-image.yaml
+++ b/scripts/developer-image.yaml
@@ -39,5 +39,6 @@ pre-install: [
    {cmd: "scripts/developer-image-pre.sh"}
 ]
 post-install: [
-   {cmd: "scripts/developer-image-post.sh ${chrootDir}"}
+   {cmd: "scripts/developer-image-post.sh ${chrootDir}"},
+   {cmd: "systemctl enable clr-installer", chroot: true}
 ]

--- a/scripts/enable-installer-post.sh
+++ b/scripts/enable-installer-post.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-echo "Enabling clr-installer on boot for $1"
-systemctl --root=$1 enable clr-installer
-
-exit 0

--- a/scripts/installer-post.sh
+++ b/scripts/installer-post.sh
@@ -2,9 +2,6 @@
 
 CHROOTPATH=$1
 
-# Enable the installer on boot
-scripts/enable-installer-post.sh ${CHROOTPATH}
-
 # Force Telemetry to use local host server
 scripts/local-telemetry-post.sh ${CHROOTPATH}
 

--- a/scripts/installer.yaml
+++ b/scripts/installer.yaml
@@ -44,5 +44,6 @@ kernel-arguments: {
 }
 
 post-install: [
-   {cmd: "scripts/installer-post.sh ${chrootDir}"}
+   {cmd: "scripts/installer-post.sh ${chrootDir}"},
+   {cmd: "systemctl enable clr-installer", chroot: true}
 ]


### PR DESCRIPTION
When using the --root option with systemctl, libsystemd for the systemd
in the chroot will be resolved on the host.  In cases where the systemd
in the chroot is a different version from the systemd on the host, this
will result in a library not found error.  Need to chroot when eanbling
clr-installer service to avoid this problem.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>

**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #249 

Changes proposed in this pull request:
- Modify config files to chroot for the systemd command that enables the clr-installer service to avoid using a non-existent libsystemd.