### PR TITLE
Fix desktop image size for USB media

### DIFF
--- a/scripts/live-desktop-beta.yaml
+++ b/scripts/live-desktop-beta.yaml
@@ -6,9 +6,11 @@ block-devices: [
    {name: "bdevice", file: "live-desktop-beta.img"}
 ]
 
+# Ensure this fits on an 8GB USB driver by sizing
+# to 8 billion bytes like manufactures
 targetMedia:
 - name: ${bdevice}
-  size: "8G"
+  size: "7800000000"
   type: disk
   children:
   - name: ${bdevice}1
@@ -23,7 +25,7 @@ targetMedia:
   - name: ${bdevice}3
     fstype: ext4
     mountpoint: /
-    size: "7.82G"
+    size: "0"  # Fill the test of the image
     type: part
 
 bundles: [


### PR DESCRIPTION
Changes proposed in this pull request:
- Reduce the live desktop beta image size to ensure it fits on an 8GB USB media
