### PR TITLE
Fixes `make lint` timeout in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
     - docker exec -it clear-test bash -c "cd /travis ; make dist-clean"
     - docker exec -it clear-test bash -c "cd /travis ; make"
     - docker exec -it clear-test bash -c "cd /travis ; PATH=${PATH}:${GOPATH}:/go/bin make vendor-check"
-    - docker exec -it clear-test bash -c "cd /travis ; make lint"
+    - travis_wait 30 sleep infinity & docker exec -it clear-test bash -c "cd /travis ; make lint"
     - travis_retry docker exec -it clear-test bash -c "cd /travis ; make check"
     - docker exec -it clear-test bash -c "cd /travis ; make clean"
     - docker exec -it clear-test bash -c "cd /travis ; make check-clean"

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ lint: build install-linters gopath
 	@rm -rf ${LOCAL_GOPATH}/src/${GO_PACKAGE_PREFIX}/vendor
 	@cp -af vendor/* ${LOCAL_GOPATH}/src/
 	@go build -race github.com/clearlinux/clr-installer/...
-	@gometalinter.v2 --deadline=10m --tests --vendor \
+	@gometalinter.v2 --deadline=30m --tests --vendor \
 	--exclude=vendor --disable-all \
 	--enable=misspell \
 	--enable=vet \


### PR DESCRIPTION
Fixes timeout issues in Travis caused due to the increase in `make lint` time because of the newly added gtk packages.

