### PR TITLE
Split the GUI and TUI

### DIFF
--- a/clr-installer/gui.go
+++ b/clr-installer/gui.go
@@ -1,0 +1,23 @@
+// +build guiBuild
+
+// Copyright © 2018 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package main
+
+import (
+	"github.com/clearlinux/clr-installer/frontend"
+	"github.com/clearlinux/clr-installer/gui"
+	"github.com/clearlinux/clr-installer/massinstall"
+	"github.com/clearlinux/clr-installer/tui"
+)
+
+// The list of possible frontends to run for GUI
+func initFrontendList() {
+	frontEndImpls = []frontend.Frontend{
+		massinstall.New(),
+		gui.New(),
+		tui.New(),
+	}
+}

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -22,16 +22,13 @@ import (
 	"github.com/clearlinux/clr-installer/crypt"
 	"github.com/clearlinux/clr-installer/errors"
 	"github.com/clearlinux/clr-installer/frontend"
-	"github.com/clearlinux/clr-installer/gui"
 	"github.com/clearlinux/clr-installer/keyboard"
 	"github.com/clearlinux/clr-installer/language"
 	"github.com/clearlinux/clr-installer/log"
-	"github.com/clearlinux/clr-installer/massinstall"
 	"github.com/clearlinux/clr-installer/model"
 	"github.com/clearlinux/clr-installer/swupd"
 	"github.com/clearlinux/clr-installer/telemetry"
 	"github.com/clearlinux/clr-installer/timezone"
-	"github.com/clearlinux/clr-installer/tui"
 	"github.com/clearlinux/clr-installer/utils"
 )
 
@@ -43,14 +40,6 @@ var (
 func fatal(err error) {
 	log.ErrorError(err)
 	panic(err)
-}
-
-func initFrontendList() {
-	frontEndImpls = []frontend.Frontend{
-		massinstall.New(),
-		gui.New(),
-		tui.New(),
-	}
 }
 
 func validateTelemetry(options args.Args, md *model.SystemInstall) error {

--- a/clr-installer/tui.go
+++ b/clr-installer/tui.go
@@ -1,0 +1,21 @@
+// +build !guiBuild
+
+// Copyright © 2018 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package main
+
+import (
+	"github.com/clearlinux/clr-installer/frontend"
+	"github.com/clearlinux/clr-installer/massinstall"
+	"github.com/clearlinux/clr-installer/tui"
+)
+
+// The list of possible frontends to run for TUI
+func initFrontendList() {
+	frontEndImpls = []frontend.Frontend{
+		massinstall.New(),
+		tui.New(),
+	}
+}


### PR DESCRIPTION
Build two different binaries for the TUI and GUI so
that we do not need to pull along overhead of the GUI
for installations without a graphics environment.

