### PR TITLE
swupd: bug fix for state dir init

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -151,7 +151,7 @@ func (args *Args) setCommandLineArgs() (err error) {
 	)
 
 	flag.StringVar(
-		&args.SwupdStateDir, "swupd-state", args.SwupdMirror, "Swupd state-dir",
+		&args.SwupdStateDir, "swupd-state", args.SwupdStateDir, "Swupd state-dir",
 	)
 
 	flag.BoolVar(


### PR DESCRIPTION
The initial value will be set incorrectly if the swupd mirror site is set.