### PR TITLE
Add ISO output support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2018 Intel Corporation
+# Copyright 2019 Intel Corporation
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
@@ -22,8 +22,11 @@ CLR_INSTALLER_TEST_HTTP_PORT ?= 8181
 
 export TEST_HTTP_PORT = ${CLR_INSTALLER_TEST_HTTP_PORT}
 
-THEME_DIR=$(DESTDIR)/usr/share/clr-installer/themes
+
+THEME_DIR=$(DESTDIR)/usr/share/clr-installer/themes/
 LOCALE_DIR=$(DESTDIR)/usr/share/locale
+ISO_TEMPLATE_DIR=$(DESTDIR)/usr/share/clr-installer/iso_templates/
+
 DESKTOP_DIR=$(DESTDIR)/usr/share/applications/
 CONFIG_DIR=$(DESTDIR)/usr/share/defaults/clr-installer/
 SYSTEMD_DIR=$(DESTDIR)/usr/lib/systemd/system/
@@ -88,6 +91,8 @@ install-common:
 	@install -D -m 644  $(top_srcdir)/themes/clr-installer.theme $(THEME_DIR)/clr-installer.theme
 	@mkdir -p -m 755 $(LOCALE_DIR)/
 	@cp -rp --no-preserve=ownership  $(top_srcdir)/locale/* $(LOCALE_DIR)/
+	@install -D -m 644  $(top_srcdir)/iso_templates/initrd_init_template $(ISO_TEMPLATE_DIR)/initrd_init_template
+	@install -D -m 644  $(top_srcdir)/iso_templates/isolinux.cfg.template $(ISO_TEMPLATE_DIR)/isolinux.cfg.template
 	@install -D -m 644  $(top_srcdir)/etc/clr-installer.yaml $(CONFIG_DIR)/clr-installer.yaml
 	@install -D -m 644  $(top_srcdir)/etc/bundles.json $(CONFIG_DIR)/bundles.json
 	@install -D -m 644  $(top_srcdir)/etc/kernels.json $(CONFIG_DIR)/kernels.json

--- a/args/args.go
+++ b/args/args.go
@@ -67,6 +67,10 @@ type Args struct {
 	BlockDevices            []string
 	StubImage               bool
 	ConvertConfigFile       string
+	MakeISO                 bool
+	MakeISOSet              bool
+	KeepImage               bool
+	KeepImageSet            bool
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -244,6 +248,14 @@ func (args *Args) setCommandLineArgs() (err error) {
 		&args.LogFile, "log-file", defaultLogFile, "The log file path",
 	)
 
+	flag.BoolVar(
+		&args.MakeISO, "iso", false, "Generate Hybrid ISO image (Legacy/UEFI bootable)",
+	)
+
+	flag.BoolVar(
+		&args.KeepImage, "keep-image", true, "Keep the generated image file (when creating ISO)",
+	)
+
 	flag.ErrHelp = errors.New("Clear Linux Installer program")
 
 	saveConfigFile := args.ConfigFile
@@ -271,6 +283,19 @@ func (args *Args) setCommandLineArgs() (err error) {
 	if fflag != nil {
 		if fflag.Changed {
 			args.ArchiveSet = true
+		}
+	}
+
+	fflag = flag.Lookup("iso")
+	if fflag != nil {
+		if fflag.Changed {
+			args.MakeISOSet = true
+		}
+	}
+	fflag = flag.Lookup("keep-image")
+	if fflag != nil {
+		if fflag.Changed {
+			args.KeepImageSet = true
 		}
 	}
 

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -218,6 +218,24 @@ func main() {
 	if options.SwupdMirror != "" {
 		md.SwupdMirror = options.SwupdMirror
 	}
+	// If ISO not set in configuration file ensure we keep the image file
+	if !md.MakeISO {
+		md.KeepImage = true
+	}
+
+	// Command line overrides the configuration file
+	if options.MakeISOSet {
+		md.MakeISO = options.MakeISO
+		if options.KeepImageSet {
+			md.KeepImage = options.KeepImage
+		} else {
+			md.KeepImage = false
+		}
+	} else {
+		if options.KeepImageSet {
+			md.KeepImage = options.KeepImage
+		}
+	}
 
 	if !options.StubImage {
 		// Now validate the mirror from the config or command line

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -455,7 +455,7 @@ func contentInstall(rootDir string, version string, model *model.SystemInstall, 
 	msg := utils.Locale.Get("Installing the base system")
 	prg := progress.NewLoop(msg)
 	log.Info(msg)
-	if err := sw.Verify(version, model.SwupdMirror); err != nil {
+	if err := sw.Verify(version, model.SwupdMirror, false); err != nil {
 		return prg, err
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/clearlinux/clr-installer/conf"
 	"github.com/clearlinux/clr-installer/errors"
 	"github.com/clearlinux/clr-installer/hostname"
+	"github.com/clearlinux/clr-installer/isoutils"
 	"github.com/clearlinux/clr-installer/keyboard"
 	"github.com/clearlinux/clr-installer/language"
 	"github.com/clearlinux/clr-installer/log"
@@ -754,6 +755,23 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 // generateISO creates an ISO image from the just created raw image
 func generateISO(rootDir string, md *model.SystemInstall) error {
 	var err error
+	msg := "Building ISO image"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
 
+	if !md.LegacyBios {
+		for _, alias := range md.StorageAlias {
+			if err = isoutils.MakeIso(rootDir, strings.TrimSuffix(alias.File, filepath.Ext(alias.File)), md); err != nil {
+				return err
+			}
+		}
+	} else {
+		err = fmt.Errorf("cannot create ISO images for configurations with LegacyBios enabled")
+		log.ErrorError(err)
+		prg.Failure()
+		return err
+	}
+
+	prg.Success()
 	return err
 }

--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -1,0 +1,150 @@
+#!/bin/sh
+
+# Mount temp filesystem
+mount -t proc none /proc
+mount -t sysfs none /sys
+mount -t devtmpfs none /dev
+mount -t tmpfs none /run
+
+shell_trap() {
+    local msg="$1"
+    while true; do
+        echo "<1>Unable to boot Clear Linux." |tee /dev/kmsg
+        echo "<1>FATAL: $msg"|tee /dev/kmsg
+        sleep 30
+    done
+}
+
+get_cpuinfo() { # return details of the first CPU only
+    cat /proc/cpuinfo | awk 'BEGIN { RS = "" ; } { printf ("%s\n", $0); exit(0); }'
+}
+
+have_cpu_feature() {
+    local feature="$1"
+    get_cpuinfo | egrep -q "^flags.*\<$feature\>"
+}
+
+check_result() {
+    local ret="$1"
+    local msg="$2"
+    [ "$ret" -ne 0 ] && { echo "<1>FAIL: $msg"|tee /dev/kmsg; shell_trap "Detected Missing Required CPU Feature: $msg"; }
+    echo "<1>SUCCESS: $msg" |tee /dev/kmsg
+}
+
+have_vmx() {
+    local feature="vmx"
+    local desc="Virtualisation support"
+    local need="$desc ($feature)"
+    have_cpu_feature "$feature"
+    check_result "$?" "$need"
+}
+
+have_ssse3_cpu_feature () {
+    local feature="ssse3"
+    local desc="Supplemental Streaming SIMD Extensions 3"
+    local need="$desc ($feature)"
+    have_cpu_feature "$feature"
+    check_result "$?" "$need"
+}
+
+have_aes_cpu_feature () {
+    local feature="aes"
+    local desc="Advanced Encryption Standard instruction set"
+    local need="$desc ($feature)"
+    have_cpu_feature "$feature"
+    check_result "$?" "$need"
+}
+
+have_pclmul_cpu_feature () {
+    local feature="pclmulqdq"
+    local desc="Carry-less Multiplication extensions"
+    local need="$desc ($feature)"
+    have_cpu_feature "$feature"
+    check_result "$?" "$need"
+}
+
+have_sse41_cpu_feature () {
+    local feature="sse4_1"
+    local desc="Streaming SIMD Extensions v4.1"
+    local need="$desc ($feature)"
+    have_cpu_feature "$feature"
+    check_result "$?" "$need"
+}
+
+have_sse42_cpu_feature () {
+    local feature="sse4_2"
+    local desc="Streaming SIMD Extensions v4.2"
+    local need="$desc ($feature)"
+    have_cpu_feature "$feature"
+    check_result "$?" "$need"
+}
+
+have_64bit_cpu() {
+    local feature="lm" # "Long mode"
+    local desc="64-bit CPU"
+    local need="$desc ($feature)"
+    have_cpu_feature "$feature"
+    check_result "$?" "$need"
+}
+
+#Verify CPU features needed to run Clear exist
+echo "<1>Checking if system is capable of running Clear Linux..." |tee /dev/kmsg
+have_64bit_cpu
+have_ssse3_cpu_feature
+have_sse41_cpu_feature
+have_sse42_cpu_feature
+have_aes_cpu_feature
+have_pclmul_cpu_feature
+
+#insmod required modules
+{{range .Modules}}
+insmod {{.}}
+{{end}}
+
+mount_root() {
+    local installer=${1}
+    mkdir /mnt/media
+    mount --read-only -t iso9660 $installer /mnt/media
+    rootfsloop=$(losetup -fP --show /mnt/media/images/rootfs.img)
+    if [ -n "${rootfsloop}" ]; then
+        mkdir /mnt/rootfs
+        mount --read-only ${rootfsloop} /mnt/rootfs
+    else
+        echo "<1>Failed to initalize loopback device for rootfs.img." |tee /dev/kmsg
+    fi
+}
+
+find_and_mount_installer() {
+    local retries=0
+
+    while [ $retries -le 5 ]; do
+        installer=$(blkid -L CLR_ISO)
+        if [ -n "${installer}" ]; then
+            echo "<1>Found installer media, continuing boot..."|tee /dev/kmsg
+            mount_root ${installer}
+            break
+        else
+            echo "<1>Failed to find installer media, retrying..."|tee /dev/kmsg
+            sleep 1
+            (( retries++ ))
+        fi
+    done
+
+    if [ $retries -ge 5 ]; then
+        shell_trap "Failed to find installer media, retries exhausted, failed to boot Clear Linux."
+    fi
+}
+
+overlay_and_switch() {
+    mkdir /mnt/ramfs
+    mount -t tmpfs -o size=512M none /mnt/ramfs
+    mkdir -p /mnt/ramfs/w_root /mnt/ramfs/workdir /mnt/ramfs/rw_root
+    mount -t overlay -o lowerdir=/mnt/rootfs,upperdir=/mnt/ramfs/w_root,workdir=/mnt/ramfs/workdir none /mnt/ramfs/rw_root
+}
+
+find_and_mount_installer
+overlay_and_switch
+
+# Switch root
+exec switch_root /mnt/ramfs/rw_root /sbin/init
+

--- a/iso_templates/isolinux.cfg.template
+++ b/iso_templates/isolinux.cfg.template
@@ -1,0 +1,10 @@
+DISPLAY boot.txt
+DEFAULT menu.c32
+TIMEOUT 50
+
+LABEL clear
+  MENU DEFAULT
+  MENU LABEL Clear Linux OS for Intel Architecture
+  LINUX /kernel/kernel.xz
+  INITRD /images/initrd.gz
+  APPEND {{.Options}}

--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -1,0 +1,574 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package isoutils
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"text/template"
+
+	"github.com/clearlinux/clr-installer/args"
+	"github.com/clearlinux/clr-installer/cmd"
+	"github.com/clearlinux/clr-installer/log"
+	"github.com/clearlinux/clr-installer/model"
+	"github.com/clearlinux/clr-installer/progress"
+	"github.com/clearlinux/clr-installer/swupd"
+	"github.com/clearlinux/clr-installer/utils"
+)
+
+type paths int
+
+const (
+	clrEfi    paths = iota + 0
+	clrImgEfi       // Location to mount the EFI partition in the passed-in img file
+	clrInitrd
+	clrRootfs
+	clrCdroot
+)
+
+var (
+	tmpPaths = make([]string, 5)
+)
+
+func mkTmpDirs() error {
+	msg := "Creating directory trees"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+	var err error
+
+	tmpPaths[clrEfi], err = ioutil.TempDir("", "clrEfi-")
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+	tmpPaths[clrInitrd], err = ioutil.TempDir("", "clrInitrd-")
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+	tmpPaths[clrCdroot], err = ioutil.TempDir("", "clrCdroot-")
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	/* Create specific directories for the new cd's root */
+	for _, d := range []string{
+		tmpPaths[clrCdroot] + "/isolinux",
+		tmpPaths[clrCdroot] + "/EFI",
+		tmpPaths[clrCdroot] + "/images",
+		tmpPaths[clrCdroot] + "/kernel",
+	} {
+		if _, err := os.Stat(d); os.IsNotExist(err) {
+			err = os.Mkdir(d, os.ModePerm)
+			if err != nil {
+				prg.Failure()
+				return err
+			}
+		}
+	}
+
+	prg.Success()
+	return err
+}
+
+func mkRootfs() error {
+	msg := "making rootfs squashfs"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	/* TODO: This takes a long time to run, it'd be nice to see it's output as it's running */
+	args := []string{
+		"mksquashfs",
+		tmpPaths[clrRootfs],
+		tmpPaths[clrCdroot] + "/images/rootfs.img",
+		"-b",
+		"131072",
+		"-comp",
+		"gzip",
+		"-e",
+		"boot/",
+		"-e",
+		"proc/",
+		"-e",
+		"sys/",
+		"-e",
+		"dev/",
+		"-e",
+		"run/",
+	}
+	err := cmd.RunAndLog(args...)
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+	prg.Success()
+	return err
+}
+
+func mkInitrd(version string, model *model.SystemInstall) error {
+	msg := "Installing the base system for initrd"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	var err error
+	options := args.Args{
+		SwupdMirror:             model.SwupdMirror,
+		SwupdStateDir:           tmpPaths[clrInitrd] + "/var/lib/swupd/",
+		SwupdStateClean:         true,
+		SwupdFormat:             "staging",
+		SwupdSkipDiskSpaceCheck: true,
+	}
+	sw := swupd.New(tmpPaths[clrInitrd], options)
+
+	/* Should install the overridden CoreBundles above (eg. os-core only) */
+	if err := sw.Verify(version, model.SwupdMirror, true); err != nil {
+		prg.Failure()
+		return err
+	}
+
+	prg.Success()
+	return err
+}
+
+func mkInitrdInitScript(templatePath string) error {
+	msg := "Creating and installing init script to initrd"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	type Modules struct {
+		Modules []string
+	}
+	mods := Modules{}
+
+	//Modules to insmod during init, paths relative to the kernel folder
+	modules := []string{
+		"/kernel/fs/isofs/isofs.ko",
+		"/kernel/drivers/cdrom/cdrom.ko",
+		"/kernel/drivers/scsi/sr_mod.ko",
+		"/kernel/fs/overlayfs/overlay.ko",
+	}
+
+	/* Find kernel, then break the name into kernelVersion */
+	kernelGlob, err := filepath.Glob(tmpPaths[clrRootfs] + "/lib/kernel/org.clearlinux.*")
+	if err != nil || len(kernelGlob) != 1 {
+		prg.Failure()
+		log.Error("Failed to determine kernel revision or > 1 kernel found")
+		return err
+	}
+	kernelTypeVersion := strings.SplitAfter(filepath.Base((kernelGlob[0])), "org.clearlinux.")[1]
+	kernelType := strings.Split(kernelTypeVersion, ".")[0] //kernelType examples: native,kvm,lts2018,hyperv
+	kernelVersion := strings.SplitAfter(kernelTypeVersion, kernelType+".")[1]
+
+	/* Copy files to initrd, and add to mods so they're added to the init template */
+	for _, i := range modules {
+		rootfsModPath := tmpPaths[clrRootfs] + "/usr/lib/modules/" + kernelVersion + "." + kernelType + i
+
+		/* copy kernel module to initramfs */
+		initrdModPath := filepath.Dir(tmpPaths[clrInitrd] + "/usr/lib/modules/" + kernelVersion + "." + kernelType + i)
+
+		if _, err := os.Stat(initrdModPath); os.IsNotExist(err) {
+			err = os.MkdirAll(initrdModPath, os.ModePerm)
+			if err != nil {
+				prg.Failure()
+				return err
+			}
+		}
+
+		err = utils.CopyFile(rootfsModPath, initrdModPath+"/"+filepath.Base(i))
+		if err != nil {
+			prg.Failure()
+			return err
+		}
+		mods.Modules = append(mods.Modules, "/usr/lib/modules/"+kernelVersion+"."+kernelType+i)
+	}
+
+	tmpl, err := ioutil.ReadFile(templatePath + "/initrd_init_template")
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to open: initrd template at %s\n", templatePath+"initrd_init_template")
+		return err
+	}
+
+	t := template.New("Modules template")
+	t, err = t.Parse(string(tmpl))
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to parse init's template")
+		return err
+	}
+
+	f, err := os.Create(tmpPaths[clrInitrd] + "/init")
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to create init file for initrd!")
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	err = t.Execute(f, mods)
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to execute template filling")
+		return err
+	}
+
+	/* Set correct owner and permissions on initrd's init */
+	if err = os.Chown(tmpPaths[clrInitrd]+"/init", 0, 0); err != nil {
+		prg.Failure()
+		return err
+	}
+	if err = os.Chmod(tmpPaths[clrInitrd]+"/init", 0700); err != nil {
+		prg.Failure()
+		return err
+	}
+
+	prg.Success()
+	return err
+}
+
+/* Build initrd image, and copy to the correct location */
+func buildInitrdImage() error {
+	msg := "Building initrd image"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	// Determine current user's path so we can revert to it when this function ends
+	currPath, err := os.Getwd()
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	/* find all files in the initrd path, create the initrd */
+	/* The find command must return filenames without a path (eg, must be run in the current dir) */
+	err = os.Chdir(tmpPaths[clrInitrd])
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	args := "sudo find .| cpio -o -H newc | gzip >" + tmpPaths[clrCdroot] + "/images/initrd.gz"
+	_, err = exec.Command("bash", "-c", args).CombinedOutput()
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	err = os.Chdir(currPath)
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	prg.Success()
+	return err
+}
+
+func mkEfiBoot() error {
+	msg := "Building efiboot image"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	cmds := [][]string{
+		{"fallocate", "-l", "100M", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
+		{"mkfs.fat", "-n", "\"CLEAR_EFI\"", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
+		{"mount", "-t", "vfat", "-o", "loop", tmpPaths[clrCdroot] + "/EFI/efiboot.img", tmpPaths[clrEfi]},
+		{"cp", "-pr", tmpPaths[clrImgEfi] + "/.", tmpPaths[clrEfi]},
+	}
+
+	for _, i := range cmds {
+		err := cmd.RunAndLog(i...)
+		if err != nil {
+			prg.Failure()
+			return err
+		}
+	}
+
+	/* create dirs in new efi img */
+	if _, err := os.Stat(tmpPaths[clrEfi] + "/EFI/systemd"); os.IsNotExist(err) {
+		err = os.MkdirAll(tmpPaths[clrEfi]+"/EFI/systemd", os.ModePerm)
+		if err != nil {
+			prg.Failure()
+			return err
+		}
+	}
+
+	/* Modify loader/entries/Clear-linux-*, add initrd= line and remove ROOT= and rootwait from kernel command line options */
+	entriesGlob, err := filepath.Glob(tmpPaths[clrEfi] + "/loader/entries/Clear-linux-*")
+	if err != nil || len(entriesGlob) != 1 {
+		prg.Failure()
+		log.Error("Failed to modify efi entries file")
+		return err
+	}
+
+	input, err := ioutil.ReadFile(entriesGlob[0])
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to read EFI entries file")
+		return err
+	}
+
+	/* Replace current options line with initrd information */
+	lines := strings.Split(string(input), "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "options") {
+			lines[i] = "initrd /EFI/BOOT/initrd.gz"
+		}
+	}
+
+	/* Pull kernel options from FS, add them to the buffer, write the file */
+	optionsGlob, err := filepath.Glob(tmpPaths[clrRootfs] + "/usr/lib/kernel/cmdline*")
+	if err != nil || len(optionsGlob) > 1 { // Fail if there's >1 kernel(s)
+		prg.Failure()
+		log.Error("Failed to determine kernel boot params for initrd")
+		return err
+	}
+	optionsFile, err := ioutil.ReadFile(optionsGlob[0])
+	if err != nil {
+		prg.Failure()
+		log.Error("Cannot read kernel options file from rootfs")
+		return err
+	}
+	lines = append(lines, "options "+string(optionsFile))
+
+	err = ioutil.WriteFile(entriesGlob[0], []byte(strings.Join(lines, "\n")), 0644)
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to write kernel boot parameters file")
+		return err
+	}
+
+	/* Copy all required files to efiboot.img and finally unmount efiboot.img */
+	paths := [][]string{
+		{tmpPaths[clrCdroot] + "/images/initrd.gz", tmpPaths[clrEfi] + "/EFI/Boot/initrd.gz"},
+		{tmpPaths[clrImgEfi] + "/EFI/BOOT/BOOTX64.EFI", tmpPaths[clrEfi] + "/EFI/systemd/systemd-bootx64.efi"},
+	}
+
+	for _, i := range paths {
+		err = utils.CopyFile(i[0], i[1])
+		if err != nil {
+			prg.Failure()
+			return err
+		}
+	}
+
+	if err := syscall.Unmount(tmpPaths[clrEfi], syscall.MNT_FORCE|syscall.MNT_DETACH); err != nil {
+		prg.Failure()
+		return err
+	}
+
+	prg.Success()
+	return err
+}
+
+func mkLegacyBoot(templatePath string) error {
+	msg := "Setting up BIOS boot with isolinux"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	type BootConf struct {
+		Options string
+	}
+	bc := BootConf{}
+
+	/* Find kernel path so we can copy the kernel later */
+	kernelGlob, err := filepath.Glob(tmpPaths[clrRootfs] + "/lib/kernel/org.clearlinux.*")
+	if err != nil || len(kernelGlob) != 1 {
+		prg.Failure()
+		return err
+	}
+	kernelPath := kernelGlob[0]
+
+	paths := [][]string{
+		{"/usr/share/syslinux/isohdpfx.bin", tmpPaths[clrCdroot] + "/isolinux/isohdpfx.bin"},
+		{"/usr/share/syslinux/isolinux.bin", tmpPaths[clrCdroot] + "/isolinux/isolinux.bin"},
+		{"/usr/share/syslinux/ldlinux.c32", tmpPaths[clrCdroot] + "/isolinux/ldlinux.c32"},
+		{"/usr/share/syslinux/menu.c32", tmpPaths[clrCdroot] + "/isolinux/menu.c32"},
+		{"/usr/share/syslinux/libutil.c32", tmpPaths[clrCdroot] + "/isolinux/libutil.c32"},
+		{kernelPath, tmpPaths[clrCdroot] + "/kernel/kernel.xz"},
+	}
+
+	for _, i := range paths {
+		err = utils.CopyFile(i[0], i[1])
+		if err != nil {
+			prg.Failure()
+			return err
+		}
+	}
+
+	/* Create the 'boot.txt' file for isolinux */
+	bootFile, err := os.Create(tmpPaths[clrCdroot] + "/isolinux/boot.txt")
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+	defer func() {
+		_ = bootFile.Close()
+	}()
+
+	_, err = bootFile.WriteString("\n\nClear Linux OS for Intel Architecture\n")
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	/* Find the (kernel boot) options file, load it into bc.Options */
+	optionsGlob, err := filepath.Glob(tmpPaths[clrRootfs] + "/lib/kernel/cmdline*")
+	if err != nil || len(optionsGlob) > 1 { // Fail if there's >1 match
+		prg.Failure()
+		log.Error("Failed to determine boot options for kernel")
+		return err
+	}
+	optionsFile, err := ioutil.ReadFile(optionsGlob[0])
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to read options file from rootfs")
+		return err
+	}
+	bc.Options = string(optionsFile)
+
+	/* Fill boot options in isolinux.cfg */
+	tmpl, err := ioutil.ReadFile(templatePath + "/isolinux.cfg.template")
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to find template")
+		return err
+	}
+
+	t := template.New("Modules template")
+	t, err = t.Parse(string(tmpl))
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to parse template.")
+		return err
+	}
+
+	f, err := os.Create(tmpPaths[clrCdroot] + "/isolinux/isolinux.cfg")
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to create isolinux.cfg on cd root!")
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	err = t.Execute(f, bc)
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to execute template filling")
+		return err
+	}
+
+	prg.Success()
+	return err
+}
+
+func packageIso(version string, imgName string) error {
+	msg := "Building ISO"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	args := []string{
+		"xorriso", "-as", "mkisofs",
+		"-o", "clear-" + version + "-" + imgName + ".iso",
+		"-V", "CLR_ISO",
+		"-isohybrid-mbr", tmpPaths[clrCdroot] + "/isolinux/isohdpfx.bin",
+		"-c", "isolinux/boot.cat", "-b", "isolinux/isolinux.bin",
+		"-no-emul-boot", "-boot-load-size", "4", "-boot-info-table",
+		"-eltorito-alt-boot", "-e", "EFI/efiboot.img", "-no-emul-boot",
+		"-isohybrid-gpt-basdat", tmpPaths[clrCdroot],
+	}
+	err := cmd.RunAndLog(args...)
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	prg.Success()
+	return err
+
+}
+
+func cleanup() {
+	msg := "Cleaning up from ISO creation"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+	var err error
+
+	/* In case something fails during mkEfiBoot, check and umount clrImgEfi */
+	if err = syscall.Unmount(tmpPaths[clrEfi], syscall.MNT_FORCE|syscall.MNT_DETACH); err != nil {
+		//Failed to unmount, usually the normal case but could bee umount actually failed.
+	}
+
+	/* Remove all directories in /tmp/clr_* */
+	for _, d := range tmpPaths {
+		if d == tmpPaths[clrRootfs] || d == tmpPaths[clrImgEfi] { //both these paths are handled by clr-installer
+			continue
+		}
+		err = os.RemoveAll(d)
+		if err != nil {
+			log.Warning("Failed to remove dir: %s", d)
+		}
+	}
+	prg.Success()
+}
+
+/*MakeIso creates an ISO image from a built image in the current directory*/
+func MakeIso(rootDir string, imgName string, model *model.SystemInstall) error {
+	tmpPaths[clrRootfs] = rootDir
+	tmpPaths[clrImgEfi] = rootDir + "/boot"
+	var err error
+
+	templateDir, err := utils.LookupISOTemplateDir()
+	if err != nil {
+		return err
+	}
+	// Determine version from the root filesystem
+	version, err := ioutil.ReadFile(rootDir + "/usr/share/clear/version")
+	if err != nil {
+		return err
+	}
+
+	if err = mkTmpDirs(); err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err = mkRootfs(); err != nil {
+		return err
+	}
+
+	if err = mkInitrd(string(version), model); err != nil {
+		return err
+	}
+
+	if err = mkInitrdInitScript(templateDir); err != nil {
+		return err
+	}
+
+	if err = buildInitrdImage(); err != nil {
+		return err
+	}
+	if err = mkEfiBoot(); err != nil {
+		return err
+	}
+	err = mkLegacyBoot(templateDir)
+	if err != nil {
+		return err
+	}
+	if err = packageIso(string(version), imgName); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/model/model.go
+++ b/model/model.go
@@ -69,6 +69,8 @@ type SystemInstall struct {
 	CopyNetwork       bool                   `yaml:"copyNetwork,omitempty,flow"`
 	Environment       map[string]string      `yaml:"env,omitempty,flow"`
 	CryptPass         string                 `yaml:"-"`
+	MakeISO           bool                   `yaml:"iso,omitempty,flow"`
+	KeepImage         bool                   `yaml:"keepImage,omitempty,flow"`
 }
 
 // InstallHook is a commands to be executed in a given point of the install process

--- a/scripts/live-desktop-beta.yaml
+++ b/scripts/live-desktop-beta.yaml
@@ -31,17 +31,24 @@ targetMedia:
 bundles: [
     bootloader,
     clr-installer,
+    c-basic,
     desktop-autostart,
     editors,
+    gimp,
+    libreoffice,
     network-basic,
     openssh-server,
     os-core,
     os-core-update,
+    package-utils,
+    pidgin,
+    Remmina,
   ]
 
 postArchive: false
 postReboot: false
 telemetry: false
+iso: true
 
 keyboard: us
 language: en_US.UTF-8

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -507,8 +507,15 @@ func (bd *BlockDevice) HumanReadableSize() (string, error) {
 
 func listBlockDevices(userDefined []*BlockDevice) ([]*BlockDevice, error) {
 	w := bytes.NewBuffer(nil)
+
+	args := []string{"partprobe", "-s"}
+	err := cmd.RunAndLog(args...)
+	if err != nil {
+		return nil, err
+	}
+
 	// Exclude memory(1), floppy(2), and SCSI CDROM(11) devices
-	err := cmd.Run(w, lsblkBinary, "--exclude", "1,2,11", "-J", "-b", "-O")
+	err = cmd.Run(w, lsblkBinary, "--exclude", "1,2,11", "-J", "-b", "-O")
 	if err != nil {
 		return nil, fmt.Errorf("%s", w.String())
 	}
@@ -516,12 +523,6 @@ func listBlockDevices(userDefined []*BlockDevice) ([]*BlockDevice, error) {
 	bds, err := parseBlockDevicesDescriptor(w.Bytes())
 	if err != nil {
 		return nil, err
-	}
-
-	for _, bd := range bds {
-		if err = bd.PartProbe(); err != nil {
-			return nil, err
-		}
 	}
 
 	if userDefined == nil || len(userDefined) == 0 {
@@ -647,10 +648,21 @@ func parseBlockDevicesDescriptor(data []byte) ([]*BlockDevice, error) {
 
 		for _, ch := range bd.Children {
 			ch.Parent = bd
+			// We ignore devices with any mount partition
 			if ch.MountPoint != "" {
 				bd.available = false
 				break
 			}
+			// We ignore devices if any partition has a CLR_ISO label
+			if strings.Contains(ch.Label, "CLR_ISO") {
+				bd.available = false
+				break
+			}
+		}
+
+		// We ignore devices if the filesystem is squashfs
+		if strings.Contains(bd.FsType, "squashfs") {
+			bd.available = false
 		}
 	}
 

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -92,7 +92,7 @@ func (s *SoftwareUpdater) setExtraFlags(args []string) []string {
 }
 
 // Verify runs "swupd verify" operation
-func (s *SoftwareUpdater) Verify(version string, mirror string) error {
+func (s *SoftwareUpdater) Verify(version string, mirror string, verifyOnly bool) error {
 	args := []string{
 		"swupd",
 		"verify",
@@ -132,6 +132,10 @@ func (s *SoftwareUpdater) Verify(version string, mirror string) error {
 		if err != nil {
 			return errors.Wrap(err)
 		}
+	}
+
+	if verifyOnly {
+		return nil
 	}
 
 	args = []string{

--- a/tests/coverage-curr-status
+++ b/tests/coverage-curr-status
@@ -18,7 +18,7 @@ ok  	github.com/clearlinux/clr-installer/model	0.013s	coverage: 92.0% of stateme
 ok  	github.com/clearlinux/clr-installer/network	0.734s	coverage: 23.5% of statements
 ?   	github.com/clearlinux/clr-installer/progress	[no test files]
 ok  	github.com/clearlinux/clr-installer/storage	0.026s	coverage: 27.0% of statements
-ok  	github.com/clearlinux/clr-installer/swupd	0.017s	coverage: 16.2% of statements
+ok  	github.com/clearlinux/clr-installer/swupd	0.017s	coverage: 15.9% of statements
 ok  	github.com/clearlinux/clr-installer/telemetry	0.317s	coverage: 35.6% of statements
 ?   	github.com/clearlinux/clr-installer/timezone	[no test files]
 ?   	github.com/clearlinux/clr-installer/tui	[no test files]

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -318,3 +318,41 @@ func SetLocale(language string) {
 		Locale.AddDomain("clr-installer")
 	}
 }
+
+// LookupISOTemplateDir returns the directory to use for reading
+// template files for ISO creation. It will look in the local developers
+// build area first, or the ENV variable, and finally the standard
+// system install location
+func LookupISOTemplateDir() (string, error) {
+	var result string
+
+	isoTemplateDirs := []string{
+		os.Getenv("CLR_INSTALLER_ISO_TEMPLATE_DIR"),
+	}
+
+	src, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		return "", err
+	}
+
+	if strings.Contains(src, "/.gopath/bin") {
+		isoTemplateDirs = append(isoTemplateDirs, strings.Replace(src, "bin", "../iso_templates", 1))
+	}
+
+	isoTemplateDirs = append(isoTemplateDirs, "/usr/share/clr-installer/iso_templates/")
+
+	for _, curr := range isoTemplateDirs {
+		if _, err := os.Stat(curr); os.IsNotExist(err) {
+			continue
+		}
+
+		result = curr
+		break
+	}
+
+	if result == "" {
+		panic(errors.Errorf("Could not find a ISO templates dir"))
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
Fixes Issue: #227

Changes proposed in this pull request:
- Add `iosutils` package which implements MakeIso() for ISO creation
- Add swupd flag to NOT install bundles beyond os-core
- Add the hook to clr-installer to build ISO files if requested.

ISO generation is based on the script `create-iso.sh`.

Questions:
 * What do I do with files that are needed for execution and need to be available on the filesystem?
   * Examples are: `isoutils/exclude, isoutils/initrd_init_template, isoutils/isolinux.cfg.template`, and both *.c32 files

 * To support a menu on Legacy systems, we need the two files `libutil.c32 and menu.c32`. These files do not exist in Clear Linux at all. The files are currently from a package in Ubuntu. What should we do?

 * There's now more prerequisites for clr-installer (but only if you intend to make ISO files). These programs are `mksquashfs, cpio, mkfs.fat, xorriso` and the bundle without executables is `bootloader`(for isolinux files). This list may not be complete.

 * I could probably move more things from RunAndLog to Go native - cp and umount for example. Suggestions?

* There are many image types that cannot have an ISO made from them at the moment, because there's a hard requirement on the image supporting EFI and the EFI partition must be mounted at '/boot' in relation to the new image's filesystem base. Any suggestions on how to report to the user/deal with this better?

* The size of the ramfs (after boot) is currently hardcoded in the initrd_init_template (line 139), should this be a config option in the YAML/somewhere? Is 256M enough?