### PR TITLE
Ensure Locale set for command line and TUI

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -248,6 +248,9 @@ func main() {
 		fatal(fmt.Errorf("Invalid Language '%s'", md.Language.Code))
 	}
 
+	// Set locale
+	utils.SetLocale(md.Language.Code)
+
 	installReboot := false
 
 	go func() {


### PR DESCRIPTION
The command line image generator users common code which requires the locale be set.