### PR TITLE
Add system compatibility checking

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -71,6 +71,7 @@ type Args struct {
 	MakeISOSet              bool
 	KeepImage               bool
 	KeepImageSet            bool
+	SystemCheck             bool
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -254,6 +255,10 @@ func (args *Args) setCommandLineArgs() (err error) {
 
 	flag.BoolVar(
 		&args.KeepImage, "keep-image", true, "Keep the generated image file (when creating ISO)",
+	)
+
+	flag.BoolVar(
+		&args.SystemCheck, "system-check", false, "Verify current system is compatible with Clear Linux and exit",
 	)
 
 	flag.ErrHelp = errors.New("Clear Linux Installer program")

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/clearlinux/clr-installer/log"
 	"github.com/clearlinux/clr-installer/model"
 	"github.com/clearlinux/clr-installer/swupd"
+	"github.com/clearlinux/clr-installer/syscheck"
 	"github.com/clearlinux/clr-installer/telemetry"
 	"github.com/clearlinux/clr-installer/timezone"
 	"github.com/clearlinux/clr-installer/utils"
@@ -268,6 +269,16 @@ func main() {
 
 	// Set locale
 	utils.SetLocale(md.Language.Code)
+
+	// Run system check and exit
+	if options.SystemCheck {
+		err = syscheck.RunSystemCheck()
+		if err != nil {
+			os.Exit(1)
+		} else {
+			os.Exit(0)
+		}
+	}
 
 	installReboot := false
 

--- a/syscheck/syscheck.go
+++ b/syscheck/syscheck.go
@@ -1,0 +1,81 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package syscheck
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/clearlinux/clr-installer/log"
+)
+
+func getCPUFeature(feature string) error {
+	cpuInfo, err := ioutil.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		log.Error("Unable to read /proc/cpuinfo")
+		return errors.New("Unable to read /proc/cpuinfo")
+	}
+	if strings.Contains(string(cpuInfo), feature) {
+		return nil
+	}
+
+	return errors.New("Missing CPU feature: " + feature)
+}
+
+func getEFIExist() error {
+	if _, err := os.Stat("/sys/firmware/efi"); os.IsNotExist(err) {
+		return errors.New("Failed to find EFI firmware")
+	}
+
+	return nil
+}
+
+// RunSystemCheck checks compatibility for clear linux. (e.g. EFI firmware, CPU featureset)
+func RunSystemCheck() error {
+	log.Info("Running system compatibility checks.")
+
+	//Check the following CPU features from /proc/cpuinfo
+	cpuFeatures := []string{
+		"lm",
+		"sse4_2",
+		"sse4_1",
+		"pclmulqdq",
+		"aes",
+		"ssse3",
+	}
+	for _, feature := range cpuFeatures {
+		fmt.Printf("Checking for required CPU feaure: %s", feature)
+		err := getCPUFeature(feature)
+		if err != nil {
+			fmt.Printf(" [*failed*]\n")
+			fmt.Println(err)
+			log.ErrorError(err)
+
+			return err
+		}
+
+		fmt.Println(" [success]")
+	}
+
+	//Check if we have EFI firmware
+	fmt.Printf("Checking for required EFI firmware")
+	err := getEFIExist()
+	if err != nil {
+		fmt.Printf(" [*failed*]\n")
+		fmt.Println(err)
+		log.ErrorError(err)
+
+		return err
+	}
+
+	fmt.Println(" [success]")
+	fmt.Println("Success: System is compatible")
+
+	log.Info("Success: System is compatible")
+	return nil
+}


### PR DESCRIPTION
Check the system meets Clear Linux's requirements before running
install.

Enable the sysCheck in the default clr-installer.yaml as well.

Currently, this checks for required CPU features and for EFI firmware
(via sysfs).

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>

Fixes Issue: #232 

Changes proposed in this pull request:
- Add syscheck package, run by default as part of Install.

Current issues:
 - Failure mode is pretty ugly with a Panic message and stack dump
 - Tests only EFI firmware and CPU features. No other checks (RAM), can only fail and not warn.
 - Failure output could be more descriptive, current looks like "Missing CPU feature: aes"