### PR TITLE
tui: sync working in TUI with GUI

### DIFF
--- a/tui/useradd.go
+++ b/tui/useradd.go
@@ -298,7 +298,7 @@ func newUseraddPage(tui *Tui) (Page, error) {
 	adminFrm := clui.CreateFrame(fldFrm, 5, 2, BorderNone, Fixed)
 	adminFrm.SetPack(clui.Vertical)
 
-	page.adminCheck = clui.CreateCheckBox(adminFrm, 1, "Administrative", Fixed)
+	page.adminCheck = clui.CreateCheckBox(adminFrm, 1, "Administrator", Fixed)
 
 	cancelBtn := CreateSimpleButton(page.cFrame, AutoSize, AutoSize, "Cancel", Fixed)
 	cancelBtn.OnClick(func(ev clui.Event) {


### PR DESCRIPTION
If we change wording in the GUI we should backport
to the TUI if the same phrase is used.
This will reduce confusion when we enable localization
in the TUI.