### PR TITLE
isoutils: Change name of produced ISO

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -473,14 +473,14 @@ func mkLegacyBoot(templatePath string) error {
 	return err
 }
 
-func packageIso(version string, imgName string) error {
+func packageIso(imgName string) error {
 	msg := "Building ISO"
 	prg := progress.NewLoop(msg)
 	log.Info(msg)
 
 	args := []string{
 		"xorriso", "-as", "mkisofs",
-		"-o", "clear-" + version + "-" + imgName + ".iso",
+		"-o", imgName + ".iso",
 		"-V", "CLR_ISO",
 		"-isohybrid-mbr", tmpPaths[clrCdroot] + "/isolinux/isohdpfx.bin",
 		"-c", "isolinux/boot.cat", "-b", "isolinux/isolinux.bin",
@@ -566,7 +566,7 @@ func MakeIso(rootDir string, imgName string, model *model.SystemInstall) error {
 	if err != nil {
 		return err
 	}
-	if err = packageIso(string(version), imgName); err != nil {
+	if err = packageIso(imgName); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Change the name of the generated ISO image to be the same as the img
file.

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>

Changes proposed in this pull request:
- Remove version string an associated plumbing from isoutils.
- Results in an ISO with the same name as the img (except for extension )

