### PR TITLE
tui: Disable console messages

### DIFF
--- a/tui/tui.go
+++ b/tui/tui.go
@@ -6,6 +6,7 @@ package tui
 
 import (
 	"github.com/clearlinux/clr-installer/args"
+	"github.com/clearlinux/clr-installer/cmd"
 	"github.com/clearlinux/clr-installer/log"
 	"github.com/clearlinux/clr-installer/model"
 	"github.com/clearlinux/clr-installer/utils"
@@ -48,6 +49,19 @@ func (tui *Tui) MustRun(args *args.Args) bool {
 
 // Run is part of the Frontend interface implementation and is the tui frontend main entry point
 func (tui *Tui) Run(md *model.SystemInstall, rootDir string, options args.Args) (bool, error) {
+	// First disable console messages
+	err := cmd.RunAndLog("dmesg", "--console--off")
+	if err != nil {
+		log.Warning("Failed to disable dmesg on console: %v", err)
+	}
+	// Defer enabling console messages
+	defer func() {
+		err := cmd.RunAndLog("dmesg", "--console--on")
+		if err != nil {
+			log.Warning("Failed to enable dmesg on console: %v", err)
+		}
+	}()
+
 	clui.InitLibrary()
 	defer clui.DeinitLibrary()
 


### PR DESCRIPTION
Forward port of change to the master branch.

Attempt to disable console messages before launching the TUI,
and re-enable upon completion.