### PR TITLE
gui: remove cancel button from telemetry

### DIFF
--- a/gui/pages/init.go
+++ b/gui/pages/init.go
@@ -62,6 +62,7 @@ type Page interface {
 type Controller interface {
 	ActivatePage(Page)
 	SetButtonState(flags Button, enabled bool)
+	SetButtonVisible(flags Button, enabled bool)
 	GetRootDir() string
 	GetOptions() args.Args
 }

--- a/gui/pages/telemetry.go
+++ b/gui/pages/telemetry.go
@@ -94,10 +94,12 @@ func (t *Telemetry) GetTitle() string {
 func (t *Telemetry) StoreChanges() {
 	t.didConfirm = true
 	t.model.EnableTelemetry(t.check.GetActive())
+	t.controller.SetButtonVisible(ButtonCancel, true)
 }
 
 // ResetChanges will reset this page to match the model
 func (t *Telemetry) ResetChanges() {
+	t.controller.SetButtonVisible(ButtonCancel, false)
 	t.controller.SetButtonState(ButtonConfirm, true)
 	t.check.SetActive(t.model.IsTelemetryEnabled())
 }

--- a/gui/window.go
+++ b/gui/window.go
@@ -544,6 +544,31 @@ func (window *Window) SetButtonState(flags pages.Button, enabled bool) {
 	}
 }
 
+// SetButtonVisible is called by the pages to view/hide certain buttons.
+func (window *Window) SetButtonVisible(flags pages.Button, visible bool) {
+	if window.menu.currentPage.GetID() != pages.PageIDWelcome {
+		if flags&pages.ButtonCancel == pages.ButtonCancel {
+			window.buttons.cancel.SetVisible(visible)
+		}
+		if flags&pages.ButtonConfirm == pages.ButtonConfirm {
+			window.buttons.confirm.SetVisible(visible)
+		}
+		if flags&pages.ButtonQuit == pages.ButtonQuit {
+			window.buttons.quit.SetVisible(visible)
+		}
+		if flags&pages.ButtonBack == pages.ButtonBack {
+			window.buttons.back.SetVisible(visible)
+		}
+	} else {
+		if flags&pages.ButtonNext == pages.ButtonNext {
+			window.buttons.next.SetVisible(visible)
+		}
+		if flags&pages.ButtonExit == pages.ButtonExit {
+			window.buttons.exit.SetVisible(visible)
+		}
+	}
+}
+
 // launchWelcomeView launches the welcome view
 func (window *Window) launchWelcomeView() {
 	window.mainLayout.Remove(window.contentLayout)


### PR DESCRIPTION
Some users were confused by having a Cancel button on the
required Telemetry screen. They assumed if the state was
what they already wanted, they could just Cancel.
We want them to Confirm each time if Telemetry is enabled
or disabled.