### PR TITLE
gui: bundle updates

### DIFF
--- a/scripts/developer-live-desktop.yaml
+++ b/scripts/developer-live-desktop.yaml
@@ -41,6 +41,8 @@ bundles: [
     bootloader,
     c-basic,
     clr-installer,
+    NetworkManager, # Add this to clr-installer-gui
+    gparted, # Add this to clr-installer-gui
     desktop-autostart,
     editors,
     gimp,


### PR DESCRIPTION
Add the NetworkManager and gparted to YAML for now
There should be added to the clr-installer-gui bundle
at release time.