### PR TITLE
gui: Desktop Launcher fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ISO_TEMPLATE_DIR=$(DESTDIR)/usr/share/clr-installer/iso_templates/
 DESKTOP_DIR=$(DESTDIR)/usr/share/applications/
 CONFIG_DIR=$(DESTDIR)/usr/share/defaults/clr-installer/
 SYSTEMD_DIR=$(DESTDIR)/usr/lib/systemd/system/
-PKIT_DIR=$(DESTDIR)/usr/share/polkit-1/actions/
+PKIT_DIR=$(DESTDIR)/usr/share/polkit-1/
 
 BUILDDATE=$(shell date -u "+%Y-%m-%d_%H:%M:%S_%Z")
 # Are we running from a Git Repo?
@@ -103,10 +103,11 @@ install-tui: build-tui install-common
 
 install-gui: build-gui install-common
 	@install -D -m 755 $(top_srcdir)/.gopath/bin/clr-installer-gui $(DESTDIR)/usr/bin/clr-installer-gui
-	@install -D -m 755 $(top_srcdir)/etc/org.clearlinux.clr-installer.policy $(PKIT_DIR)/org.clearlinux.clr-installer.policy
+	@install -D -m 644 $(top_srcdir)/etc/org.clearlinux.clr-installer-gui.policy $(PKIT_DIR)/actions/org.clearlinux.clr-installer-gui.policy
+	@install -D -m 644 $(top_srcdir)/etc/org.clearlinux.clr-installer-gui.rules $(PKIT_DIR)/rules.d/org.clearlinux.clr-installer-gui.rules
 	@install -D -m 644 $(top_srcdir)/themes/clr.png $(THEME_DIR)/clr.png
 	@install -D -m 644 $(top_srcdir)/themes/style.css $(THEME_DIR)/style.css
-	@install -D -m 644 $(top_srcdir)/etc/clr-installer.desktop $(DESKTOP_DIR)/clr-installer.desktop
+	@install -D -m 644 $(top_srcdir)/etc/clr-installer-gui.desktop $(DESKTOP_DIR)/clr-installer-gui.desktop
 
 uninstall:
 	@rm -f $(DESTDIR)/usr/bin/clr-installer

--- a/etc/clr-installer-gui.desktop
+++ b/etc/clr-installer-gui.desktop
@@ -2,13 +2,14 @@
 Type=Application
 Encoding=UTF-8
 Name=Install Clear Linux* OS
-Name[es]=MX: Install Clear Linux* OS
+Name[es_MX]=MX: Install Clear Linux* OS
 Name[zh_CN]=CN: Install Clear Linux* OS
 Comment=Clear Linux* OS Installer
-Comment[es]=MX: Clear Linux* OS Installer
+Comment[es_MX]=MX: Clear Linux* OS Installer
 Comment[zh_CN]=MX: Clear Linux* OS Installer
 Icon=/usr/share/clr-installer/themes/clr.png
-Exec=sudo /usr/bin/clr-installer-gui
+Exec=pkexec /usr/bin/clr-installer-gui
+StartupWMClass=clr-installer-gui
 Terminal=false
 Categories=X-GNOME-Settings-Panel;GTK;System;Settings;
 Keywords=Install;SystemSettings;

--- a/etc/org.clearlinux.clr-installer-gui.policy
+++ b/etc/org.clearlinux.clr-installer-gui.policy
@@ -3,12 +3,16 @@
 "http://www.freedesktop.org/software/polkit/policyconfig-1.dtd">
 <policyconfig>
 
-  <vendor>Clear Linux OS Installer</vendor>
+  <vendor>Clear Linux* OS Installer</vendor>
   <vendor_url>https://github.com/clearlinux/clr-installer</vendor_url>
 
-  <action id="org.clearlinux.clr-installer.start">
-    <description>Install Clear Linux OS</description>
-    <message>Authentication is required to install Clear Linux OS</message>
+  <action id="org.clearlinux.clr-installer-gui.start">
+    <description>Install Clear Linux* OS</description>
+    <description xml:lang="es_MX">MX: Install Clear Linux* OS</description>
+    <description xml:lang="zh_CN">CN: Install Clear Linux* OS</description>
+    <message>Authentication is required to install Clear Linux* OS</message>
+    <message xml:lang="es_MX">MX: Authentication is required to install Clear Linux* OS</message>
+    <message xml:lang="zh_CN">CN: Authentication is required to install Clear Linux* OS</message>
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>

--- a/etc/org.clearlinux.clr-installer-gui.rules
+++ b/etc/org.clearlinux.clr-installer-gui.rules
@@ -1,0 +1,9 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.clearlinux.clr-installer-gui.start") {
+            if (subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+            } else {
+                return polkit.Result.AUTH_ADMIN;
+            }
+    }
+});

--- a/scripts/live-desktop-post-install.sh
+++ b/scripts/live-desktop-post-install.sh
@@ -58,7 +58,7 @@ kernel: kernel-native
 DESKTOP_YAML_DEFAULT
 chmod 644 $VAR_DIR/clr-installer.yaml
 
-FAVORITE_APPS="['clr-installer.desktop', 'org.gnome.Terminal.desktop', \
+FAVORITE_APPS="['clr-installer-gui.desktop', 'org.gnome.Terminal.desktop', \
        'org.gnome.Nautilus.desktop', 'firefox.desktop', \
        'org.gnome.Evolution.desktop']"
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Made all files and actions consistent with the clr-installer-gui name.
- Fix security of starting Installer; user pkexec not sudo; added new rule for clr-installer-gui.
- Fix bug so only one icon is present when running.


