### PR TITLE
scripts: Disable autoUpdate

### DIFF
--- a/scripts/developer-live-desktop.yaml
+++ b/scripts/developer-live-desktop.yaml
@@ -60,6 +60,7 @@ postArchive: false
 postReboot: false
 telemetry: false
 iso: true
+autoUpdate: false
 
 keyboard: us
 language: en_US.UTF-8

--- a/scripts/developer-live-server.yaml
+++ b/scripts/developer-live-server.yaml
@@ -41,6 +41,7 @@ postArchive: false
 postReboot: false
 telemetry: false
 iso: true
+autoUpdate: false
 
 keyboard: us
 language: en_US.UTF-8


### PR DESCRIPTION
For the developer images, we want to disable autoUpdate for the ISO
images.  DevOps always add the version= option which disables
autoUpdate automatically.