### PR TITLE
script: Remove extra desktop icon

### DIFF
--- a/scripts/developer-live-desktop.yaml
+++ b/scripts/developer-live-desktop.yaml
@@ -81,6 +81,7 @@ post-install: [
    {cmd: "${yamlDir}/live-image-post-update-version.py ${chrootDir}"},
    {cmd: "${yamlDir}/live-desktop-post-install.sh ${chrootDir}"},
    {cmd: "${yamlDir}/developer-image-post.sh ${chrootDir}"},
+   {cmd: "/bin/rm -f ${chrootDir}/usr/share/applications/clr-installer.desktop"},
 ]
 
 version: 0


### PR DESCRIPTION
The developer image installs the local code over the released
clr-installer bundle. This leaves the old desktop icon for
the TUI. Manually remove for now; it won't be present in the
production release.