### PR TITLE
Fix a bug in Partial truncating an integer value

### DIFF
--- a/tui/install.go
+++ b/tui/install.go
@@ -74,8 +74,8 @@ func (page *InstallPage) Desc(desc string) {
 // Partial is part of the progress.Client implementation and adjusts the progress bar to the
 // current completion percentage
 func (page *InstallPage) Partial(total int, step int) {
-	perc := (step / total)
-	value := page.prgMax * perc
+	perc := float32(step) / float32(total)
+	value := int(float32(page.prgMax) * perc)
 	page.prgBar.SetValue(int(value))
 }
 


### PR DESCRIPTION
The Partial() function is used to report a partial progress in a
progress bar. When using this function the value set on the progress bar
was always zero since it was doing a division of two integers that were
always resulting in a number < 1 which was being truncated because both
numbers were integers so go was using an integer to store the result
too.

This commit fixes the bug by converting the values to the right types.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>