### PR TITLE
Use the JSON output from swupd to report progress

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -469,6 +469,8 @@ func runInstallHook(vars map[string]string, hook *model.InstallHook) error {
 // executed using the target swupd
 func contentInstall(rootDir string, version string, model *model.SystemInstall, options args.Args) (progress.Progress, error) {
 
+	var prg progress.Progress
+
 	sw := swupd.New(rootDir, options)
 
 	bundles := model.Bundles
@@ -482,17 +484,15 @@ func contentInstall(rootDir string, version string, model *model.SystemInstall, 
 	}
 
 	msg := utils.Locale.Get("Installing base OS and configured bundles")
-	prg := progress.NewLoop(msg)
 	log.Info(msg)
 	log.Debug("Installing bundles: %s", strings.Join(bundles, ", "))
 	if err := sw.VerifyWithBundles(version, model.SwupdMirror, bundles); err != nil {
 		return prg, err
 	}
-	prg.Success()
 
 	if !model.AutoUpdate {
 		msg := utils.Locale.Get("Disabling automatic updates")
-		prg := progress.NewLoop(msg)
+		prg = progress.NewLoop(msg)
 		log.Info(msg)
 		if err := sw.DisableUpdate(); err != nil {
 			warnMsg := utils.Locale.Get("Disabling automatic updates failed")


### PR DESCRIPTION
When running the "swupd verify" command to install the base OS and the
selected bundles, the progress of the command execution was just being
shown as a progress bar that was looping until the swupd command
finished. This approach was not ideal since this process can take
several minutes to complete, and since the progress bar was just
spinning it didn't provide a real feedback for the user to know in what
part the process was. This can trigger some anxiety in users.

This commit solves this problem by using the machine readable output
from swupd to determine the exact part of the process where the install is
and report this to the user using a series of steps along with a progress
bar (or percentage value in not TUI installer) that shows how far the
step has gotten.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>
