### PR TITLE
isoutils: Add Rufus ISO image support

### DIFF
--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -9,7 +9,7 @@ mount -t tmpfs none /run
 shell_trap() {
     local msg="$1"
     while true; do
-        echo "<1>Unable to boot Clear Linux." |tee /dev/kmsg
+        echo "<1>Unable to boot Clear Linux*." |tee /dev/kmsg
         echo "<1>FATAL: $msg"|tee /dev/kmsg
         sleep 30
     done
@@ -88,7 +88,7 @@ have_64bit_cpu() {
 }
 
 #Verify CPU features needed to run Clear exist
-echo "<1>Checking if system is capable of running Clear Linux..." |tee /dev/kmsg
+echo "<1>Checking if system is capable of running Clear Linux*..." |tee /dev/kmsg
 have_64bit_cpu
 have_ssse3_cpu_feature
 have_sse41_cpu_feature
@@ -104,7 +104,7 @@ insmod {{.}}
 mount_root() {
     local installer=${1}
     mkdir /mnt/media
-    mount --read-only -t iso9660 $installer /mnt/media
+    mount --read-only $installer /mnt/media
     rootfsloop=$(losetup -fP --show /mnt/media/images/rootfs.img)
     if [ -n "${rootfsloop}" ]; then
         mkdir /mnt/rootfs
@@ -131,7 +131,7 @@ find_and_mount_installer() {
     done
 
     if [ $retries -ge 5 ]; then
-        shell_trap "Failed to find installer media, retries exhausted, failed to boot Clear Linux."
+        shell_trap "Failed to find installer media, retries exhausted, failed to boot Clear Linux*."
     fi
 }
 

--- a/iso_templates/isolinux.cfg.template
+++ b/iso_templates/isolinux.cfg.template
@@ -4,7 +4,7 @@ TIMEOUT 50
 
 LABEL clear
   MENU DEFAULT
-  MENU LABEL Clear Linux OS for Intel Architecture
+  MENU LABEL Clear Linux* OS
   LINUX /kernel/kernel.xz
-  INITRD /images/initrd.gz
+  INITRD /EFI/BOOT/initrd.gz
   APPEND {{.Options}}


### PR DESCRIPTION
Rufus in iso image mode creates a new filesystem and copies all files
from the iso onto that filesystem. This broke Clear boot because there
were missing files from the CD root to boot (those files were in
efiboot.img), and because initrd was limited to mounting only ISO files
to find the rootfs.

Now the files from efiboot.img are copied to the ISO root (so that Rufus
will now work), the initrd paths have been made congruent (though there
are two initrd.gz files - one in efiboot.img and one on the ISO root),
and some extraneous systemd files have been removed.

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>

Changes proposed in this pull request:
- Fix Rufus' ISO Image mode
- Make initrd paths on kernel cmdline congruent
- Remove extraneous systemd boot files

This may have a side-effect of bloating the image slightly (by probably 32MB), but I can't see a way to avoid this as having two copies is crucial to support all 4 boot methods (Rufus ISO/dd) and (efi/legacy)