### PR TITLE
user: Only allow lower case letter for login

### DIFF
--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -230,8 +230,8 @@ msgstr "Login is required"
 msgid "Login maximum length is %d"
 msgstr "Login maximum length is %d"
 
-msgid "Login must contain only numbers, letters, - or _"
-msgstr "Login must contain only numbers, letters, - or _"
+msgid "Login must contain only numbers, lower case letters, - or _"
+msgstr "Login must contain only numbers, lower case letters, - or _"
 
 msgid "Password is required"
 msgstr "Password is required"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -230,8 +230,8 @@ msgstr "Debe iniciar sesión."
 msgid "Login maximum length is %d"
 msgstr "La extensión máxima del inicio de sesión debe ser de %d."
 
-msgid "Login must contain only numbers, letters, - or _"
-msgstr "El inicio de sesión solo debe contener números, letras, - o _."
+msgid "Login must contain only numbers, lower case letters, - or _"
+msgstr "El inicio de sesión solo debe contener números, letras minúsculas, - o _."
 
 msgid "Password is required"
 msgstr "Se requiere una contraseña."

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -230,8 +230,8 @@ msgstr "需要登录"
 msgid "Login maximum length is %d"
 msgstr "登录名最大长度为 %d"
 
-msgid "Login must contain only numbers, letters, - or _"
-msgstr "登录名必须只包含数字、字母、连字符和下划线"
+msgid "Login must contain only numbers, lower case letters, - or _"
+msgstr "登录名必须仅包含数字、小写字母、连字符和下划线"
 
 msgid "Password is required"
 msgstr "需要密码"

--- a/user/user.go
+++ b/user/user.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	usernameExp     = regexp.MustCompile("^([a-zA-Z]+[0-9a-zA-Z-_ ,'.]*|)$")
-	loginExp        = regexp.MustCompile("^[a-zA-Z]+[0-9a-zA-Z-_]*$")
+	loginExp        = regexp.MustCompile("^[a-z]+[0-9a-z-_]*$")
 	sysDefaultUsers = []string{}
 )
 
@@ -441,7 +441,7 @@ func IsValidLogin(login string) (bool, string) {
 	}
 
 	if !loginExp.MatchString(login) {
-		return false, utils.Locale.Get("Login must contain only numbers, letters, - or _")
+		return false, utils.Locale.Get("Login must contain only numbers, lower case letters, - or _")
 	}
 
 	return true, ""


### PR DESCRIPTION
Recently discovered Clear Linux only allows lower case letter
as part of a login name. Updated validation check and error message.