### PR TITLE
gui: Handle errors in the Install page

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -579,16 +579,19 @@ func configureNetwork(model *model.SystemInstall) (progress.Progress, error) {
 			ok = true
 			break
 		}
+		log.Warning("Attempt to verify connectivity failed")
 
 		// Restart networking if we failed
 		// The likely gain is restarting pacdiscovery to fix autoproxy
 		if err := network.Restart(); err != nil {
-			return prg, err
+			log.Warning("Network restart failed")
+			ok = false
+			break
 		}
 	}
 
 	if !ok {
-		return prg, errors.Errorf("Failed, network is not working.")
+		return prg, errors.Errorf(utils.Locale.Get("Network is not working."))
 	}
 
 	prg.Success()

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -481,3 +481,11 @@ msgstr "Skipping new file system for %s"
 
 msgid "Disabled"
 msgstr "Disabled"
+
+# TRANSLATION SET: 4
+
+msgid "Installation failed."
+msgstr "Installation failed."
+
+msgid "Network is not working."
+msgstr "Network is not working."

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -481,3 +481,11 @@ msgstr "Omitir nuevo sistema de archivos para %s"
 
 msgid "Disabled"
 msgstr "Desactivada"
+
+# TRANSLATION SET: 4
+
+msgid "Installation failed."
+msgstr "MX: Installation failed."
+
+msgid "Network is not working."
+msgstr "MX: Network is not working."

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -481,3 +481,11 @@ msgstr "跳过 %s 的新文件系统"
 
 msgid "Disabled"
 msgstr "已禁用"
+
+# TRANSLATION SET: 4
+
+msgid "Installation failed."
+msgstr "CN: Installation failed."
+
+msgid "Network is not working."
+msgstr "CN: Network is not working."


### PR DESCRIPTION
Handle errors during installation.
Displays an error message on screen instead of panic and crashing.
This handles the network connectivity error. 

TODO: 
- Get the new strings translated.
- Test for network connectivity on click on Install button before launching the Install screen.
