### PR TITLE
scripts: set prompt via hostname

### DIFF
--- a/scripts/installer-post.sh
+++ b/scripts/installer-post.sh
@@ -11,7 +11,7 @@ scripts/wait-to-boot-post.sh ${CHROOTPATH}
 # Add issue (pre-login message) to inform user of how to run the installer
 scripts/add-login-issue.sh ${CHROOTPATH}
 
-# Add changes to PS1 to indicate live image
-scripts/ps1-override.sh ${CHROOTPATH}
+# Add changes to PS1 to indicate live image by setting the hostname
+echo "clr-live" > ${CHROOTPATH}/etc/hostname
 
 exit 0

--- a/scripts/ps1-override.sh
+++ b/scripts/ps1-override.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-echo "Setting custom PS1 terminal prompt $1"
-
-echo "PS1='\[\e[38;5;39m\]\u\[\e[0m\]@\[\e[38;5;208m\]clr-live \[\e[38;5;39m\]\w \[\e[38;5;39m\]# \[\e[0;0m\]'" >> $1/etc/profile
-
-exit 0


### PR DESCRIPTION
Changes proposed in this pull request:
- Set the hostname for the live image prompt

Fixes bug where the desktop image terminal has incorrect '#' at the end of the prompt instead of the desired '$'.

