### PR TITLE
iso: Pass all options through to ISO generation

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -412,7 +412,7 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		msg = "Generating ISO image"
 		prg = progress.NewLoop(msg)
 		log.Info(msg)
-		if err = generateISO(rootDir, model); err != nil {
+		if err = generateISO(rootDir, model, options); err != nil {
 			log.ErrorError(err)
 		}
 		prg.Success()
@@ -760,7 +760,7 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 }
 
 // generateISO creates an ISO image from the just created raw image
-func generateISO(rootDir string, md *model.SystemInstall) error {
+func generateISO(rootDir string, md *model.SystemInstall, options args.Args) error {
 	var err error
 	msg := "Building ISO image"
 	prg := progress.NewLoop(msg)
@@ -768,7 +768,7 @@ func generateISO(rootDir string, md *model.SystemInstall) error {
 
 	if !md.LegacyBios {
 		for _, alias := range md.StorageAlias {
-			if err = isoutils.MakeIso(rootDir, strings.TrimSuffix(alias.File, filepath.Ext(alias.File)), md); err != nil {
+			if err = isoutils.MakeIso(rootDir, strings.TrimSuffix(alias.File, filepath.Ext(alias.File)), md, options); err != nil {
 				return err
 			}
 		}

--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -112,19 +112,14 @@ func mkRootfs() error {
 	return err
 }
 
-func mkInitrd(version string, model *model.SystemInstall) error {
+func mkInitrd(version string, model *model.SystemInstall, options args.Args) error {
 	msg := "Installing the base system for initrd"
 	prg := progress.NewLoop(msg)
 	log.Info(msg)
 
 	var err error
-	options := args.Args{
-		SwupdMirror:             model.SwupdMirror,
-		SwupdStateDir:           tmpPaths[clrInitrd] + "/var/lib/swupd/",
-		SwupdStateClean:         true,
-		SwupdFormat:             "staging",
-		SwupdSkipDiskSpaceCheck: true,
-	}
+	options.SwupdStateDir = tmpPaths[clrInitrd] + "/var/lib/swupd/"
+	options.SwupdFormat = "staging"
 	sw := swupd.New(tmpPaths[clrInitrd], options)
 
 	/* Should install the overridden CoreBundles above (eg. os-core only) */
@@ -537,7 +532,7 @@ func cleanup() {
 }
 
 /*MakeIso creates an ISO image from a built image in the current directory*/
-func MakeIso(rootDir string, imgName string, model *model.SystemInstall) error {
+func MakeIso(rootDir string, imgName string, model *model.SystemInstall, options args.Args) error {
 	tmpPaths[clrRootfs] = rootDir
 	tmpPaths[clrImgEfi] = rootDir + "/boot"
 	var err error
@@ -561,7 +556,7 @@ func MakeIso(rootDir string, imgName string, model *model.SystemInstall) error {
 		return err
 	}
 
-	if err = mkInitrd(string(version), model); err != nil {
+	if err = mkInitrd(string(version), model, options); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We need to pass the full suite of options to the ISO
generation code to ensure the call to swupd has all
of the requested options.