### PR TITLE
tui: gui: Do not display version in Demo mode

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -112,7 +112,7 @@ func main() {
 	}
 
 	if options.DemoMode {
-		model.Version = "X.Y.Z"
+		model.Version = model.DemoVersion
 	}
 	// Make the Version of the program visible to telemetry
 	telemetry.ProgVersion = model.Version

--- a/gui/window.go
+++ b/gui/window.go
@@ -688,7 +688,9 @@ func (window *Window) GetRootDir() string {
 // GetWelcomeMessage gets the welcome message
 func GetWelcomeMessage() string {
 	text := "<span font-size='xx-large'>" + utils.Locale.Get("Welcome to Clear Linux* OS Desktop Installation") + "</span>"
-	text += "\n\n<small>" + utils.Locale.Get("VERSION %s", model.Version) + "</small>"
+	if model.Version != model.DemoVersion {
+		text += "\n\n<small>" + utils.Locale.Get("VERSION %s", model.Version) + "</small>"
+	}
 
 	return text
 }
@@ -696,7 +698,9 @@ func GetWelcomeMessage() string {
 // GetThankYouMessage gets the thank you message
 func GetThankYouMessage() string {
 	text := "<span font-size='xx-large'>" + utils.Locale.Get("Thank you for choosing Clear Linux* OS") + "</span>"
-	text += "\n\n<small>" + utils.Locale.Get("VERSION %s", model.Version) + "</small>"
+	if model.Version != model.DemoVersion {
+		text += "\n\n<small>" + utils.Locale.Get("VERSION %s", model.Version) + "</small>"
+	}
 
 	return text
 }

--- a/model/model.go
+++ b/model/model.go
@@ -27,6 +27,13 @@ import (
 	"github.com/clearlinux/clr-installer/utils"
 )
 
+const (
+	// DemoVersion is hard coded string we display in log files
+	// when running in demo (aka documentation mode). We will
+	// now use this as a flag to not include the version in UI.
+	DemoVersion = "X.Y.Z"
+)
+
 // Version of Clear Installer.
 // Also used by the Makefile for releases.
 // Default to the version of the program

--- a/tui/common.go
+++ b/tui/common.go
@@ -387,8 +387,12 @@ func (page *BasePage) newWindow() {
 
 	// Default all the windows to borderless
 	clui.WindowManager().SetBorder(clui.BorderNone)
-	page.window = clui.AddWindow(x, y, WindowWidth, WindowHeight,
-		" [Clear Linux* OS Installer ("+model.Version+")] ")
+	title := " [Clear Linux* OS Installer"
+	if model.Version != model.DemoVersion {
+		title = title + " (" + model.Version + ")"
+	}
+	title = title + "] "
+	page.window = clui.AddWindow(x, y, WindowWidth, WindowHeight, title)
 
 	page.window.SetTitleButtons(0)
 	page.window.SetSizable(false)


### PR DESCRIPTION
For documentation purposes (screenshots), we do not want to
include the version string. Having a version string in the image
requires updating all image each release.