### PR TITLE
Use the JSON output from swupd to report progress

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,12 @@ import (
 
 	"github.com/clearlinux/clr-installer/log"
 )
+
+// Output interface allows implementors to process the output from a
+// command according to their specific case
+type Output interface {
+	Process(line string)
+}
 
 type runLogger struct{}
 
@@ -115,4 +122,58 @@ func run(sw func(cmd *exec.Cmd) error, writer io.Writer, env map[string]string, 
 // args are the actual command and its arguments
 func Run(writer io.Writer, args ...string) error {
 	return run(nil, writer, nil, args...)
+}
+
+// RunAndProcessOutput executes a command and process the output from
+// Stdout and Stderr according to the implementor
+// args are the actual command and its arguments
+func RunAndProcessOutput(output Output, args ...string) error {
+
+	var exe string
+	var cmdArgs []string
+
+	log.Debug("%s", strings.Join(args, " "))
+
+	exe = args[0]
+	cmdArgs = args[1:]
+
+	cmd := exec.Command(exe, cmdArgs...)
+
+	if httpsProxy != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("https_proxy=%s", httpsProxy))
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Error("Could not connect a pipe to Stdout")
+		return err
+	}
+
+	// run the command but don't wait for it to finish
+	if err := cmd.Start(); err != nil {
+		log.Error("Failed to start command execution")
+		return err
+	}
+
+	// start scanning stdout for messages
+	scannerOut := bufio.NewScanner(stdout)
+	for scannerOut.Scan() {
+
+		// specific processing implementation
+		output.Process(scannerOut.Text())
+
+	}
+
+	if err := scannerOut.Err(); err != nil {
+		log.Error("An error occurred while reading stdout")
+		return err
+	}
+
+	// wait for the command to finish running
+	if err := cmd.Wait(); err != nil {
+		log.Error("An error occurred executing command: \"%s\". Error: %s", strings.Join(args, " "), err)
+		return err
+	}
+
+	return nil
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -466,6 +466,8 @@ func runInstallHook(vars map[string]string, hook *model.InstallHook) error {
 // executed using the target swupd
 func contentInstall(rootDir string, version string, model *model.SystemInstall, options args.Args) (progress.Progress, error) {
 
+	var prg progress.Progress
+
 	sw := swupd.New(rootDir, options)
 
 	bundles := model.Bundles
@@ -479,17 +481,18 @@ func contentInstall(rootDir string, version string, model *model.SystemInstall, 
 	}
 
 	msg := utils.Locale.Get("Installing base OS and configured bundles")
-	prg := progress.NewLoop(msg)
 	log.Info(msg)
 	log.Debug("Installing bundles: %s", strings.Join(bundles, ", "))
 	if err := sw.VerifyWithBundles(version, model.SwupdMirror, bundles); err != nil {
+		// If the swupd command failed to run there wont be a progress
+		// bar, so we need to create a new one that we can fail
+		prg = progress.NewLoop(msg)
 		return prg, err
 	}
-	prg.Success()
 
 	if !model.AutoUpdate {
 		msg := utils.Locale.Get("Disabling automatic updates")
-		prg := progress.NewLoop(msg)
+		prg = progress.NewLoop(msg)
 		log.Info(msg)
 		if err := sw.DisableUpdate(); err != nil {
 			warnMsg := utils.Locale.Get("Disabling automatic updates failed")

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -502,3 +502,24 @@ msgstr "Failed to find EFI firmware"
 
 msgid "Rescanning media"
 msgstr "Rescanning media"
+
+msgid "Resolving OS versions"
+msgstr "Resolving OS versions"
+
+msgid "Cleaning up download directory"
+msgstr "Cleaning up download directory"
+
+msgid "Downloading required manifests"
+msgstr "Downloading required manifests"
+
+msgid "Resolving files that need to be installed"
+msgstr "Resolving files that need to be installed"
+
+msgid "Downloading required packs"
+msgstr "Downloading required packs"
+
+msgid "Verifying files integrity"
+msgstr "Verifying files integrity"
+
+msgid "Downloading missing files"
+msgstr "Downloading missing files"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -502,3 +502,24 @@ msgstr "Error al encontrar el firmware EFI"
 
 msgid "Rescanning media"
 msgstr "Re-escaneo de medios"
+
+msgid "Resolving OS versions"
+msgstr "Resolviendo las versiones del SO"
+
+msgid "Cleaning up download directory"
+msgstr "Limpiando el directorio de descarga"
+
+msgid "Downloading required manifests"
+msgstr "Descargando los manifestos requeridos"
+
+msgid "Resolving files that need to be installed"
+msgstr "Resolviendo los archivos que necesitan ser instalados"
+
+msgid "Downloading required packs"
+msgstr "Descargando los paquestes requeridos"
+
+msgid "Verifying files integrity"
+msgstr "Verificando la integridad de archivos"
+
+msgid "Downloading missing files"
+msgstr "Descargando los archivos faltantes"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -502,3 +502,24 @@ msgstr "无法找到EFI固件"
 
 msgid "Rescanning media"
 msgstr "重新扫描媒体"
+
+msgid "Resolving OS versions"
+msgstr "解析操作系统版本"
+
+msgid "Cleaning up download directory"
+msgstr "清理下载目录"
+
+msgid "Downloading required manifests"
+msgstr "下载所需的清单"
+
+msgid "Resolving files that need to be installed"
+msgstr "解析需要安装的文件"
+
+msgid "Downloading required packs"
+msgstr "下载所需的包"
+
+msgid "Verifying files integrity"
+msgstr "验证文件完整性"
+
+msgid "Downloading missing files"
+msgstr "下载丢失的文件"

--- a/tui/install.go
+++ b/tui/install.go
@@ -67,6 +67,7 @@ func (page *InstallPage) Step() {
 
 // Desc is part of the progress.Client implementation and sets the progress bar label
 func (page *InstallPage) Desc(desc string) {
+	page.prgBar.SetValue(0)
 	page.prgLabel.SetTitle(desc)
 	clui.RefreshScreen()
 }
@@ -77,6 +78,7 @@ func (page *InstallPage) Partial(total int, step int) {
 	perc := float32(step) / float32(total)
 	value := int(float32(page.prgMax) * perc)
 	page.prgBar.SetValue(int(value))
+	clui.RefreshScreen()
 }
 
 // LoopWaitDuration is part of the progress.Client implementation and returns the time duration


### PR DESCRIPTION
Fixes Issue: #12 

When running the "swupd verify" command to install the base OS and the
selected bundles, the progress of the command execution was just being
shown as a progress bar that was looping until the swupd command
finished. This approach was not ideal since this process can take
several minutes to complete, and since the progress bar was just
spinning it didn't provide a real feedback for the user to know in what
part the process was. This can trigger some anxiety in users.

This commit solves this problem by using the machine readable output
from swupd to determine the exact part of the process where the install is
and report this to the user using a series of steps along with a progress
bar (or percentage value in not TUI installer) that shows how far the
step has gotten.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>



