### PR TITLE
gui: Add vlc as default bundle

### DIFF
--- a/etc/bundles.json
+++ b/etc/bundles.json
@@ -87,6 +87,10 @@
     {
       "name": "user-basic-dev",
       "desc": "Packages to build the user-basic bundle"
+    },
+    {
+      "name": "vlc",
+      "desc": "Media player"
     }
   ]
 }

--- a/gui/pages/bundle.go
+++ b/gui/pages/bundle.go
@@ -158,6 +158,7 @@ func NewBundlePage(controller Controller, model *model.SystemInstall) (Page, err
 		bundle.checks.Add(wid)
 		bundle.selections = append(bundle.selections, wid)
 	}
+	bundle.model.AddUserBundle("vlc") // Add vlc by default
 
 	return bundle, nil
 }

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -483,3 +483,7 @@ msgstr "Installation failed."
 
 msgid "Network is not working."
 msgstr "Network is not working."
+
+msgid "Media player"
+msgstr "Media player"
+

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -483,3 +483,7 @@ msgstr "Instalación fallida."
 
 msgid "Network is not working."
 msgstr "La red no está funcionando."
+
+msgid "Media player"
+msgstr "Reproductor multimedia"
+

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -483,3 +483,7 @@ msgstr "安装失败。"
 
 msgid "Network is not working."
 msgstr "网络无法正常工作。"
+
+msgid "Media player"
+msgstr "媒体播放器"
+


### PR DESCRIPTION
As per Ianeta's request, adding vlc pundle that is selected by default. This is done so that CL videos can be played without crashing. 


