### PR TITLE
Add syscheck and localized error dialog

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -300,7 +300,7 @@ func main() {
 
 	// Run system check and exit
 	if options.SystemCheck {
-		err = syscheck.RunSystemCheck()
+		err = syscheck.RunSystemCheck(false)
 		if err != nil {
 			os.Exit(1)
 		} else {

--- a/gui/common/common.go
+++ b/gui/common/common.go
@@ -51,6 +51,26 @@ func CreateDialog(contentBox *gtk.Box, title string) (*gtk.Dialog, error) {
 	return widget, nil
 }
 
+// CreateDialogOneButton creates a gtk dialog with a single button
+func CreateDialogOneButton(contentBox *gtk.Box, title, buttonLabel, buttonStyle string) (*gtk.Dialog, error) {
+	var err error
+	widget, err := CreateDialog(contentBox, title)
+	if err != nil {
+		return nil, err
+	}
+	widget.SetSkipTaskbarHint(false)
+	widget.SetResizable(false)
+
+	buttonExit, err := SetButton(buttonLabel, buttonStyle)
+	if err != nil {
+		return nil, err
+	}
+	buttonExit.SetMarginEnd(ButtonSpacing)
+	widget.AddActionWidget(buttonExit, gtk.RESPONSE_CANCEL)
+
+	return widget, nil
+}
+
 // CreateDialogOkCancel creates a gtk dialog with Ok and Cancel buttons
 func CreateDialogOkCancel(contentBox *gtk.Box, title, ok, cancel string) (*gtk.Dialog, error) {
 	//parentWindow := GetWinHandle()

--- a/gui/window.go
+++ b/gui/window.go
@@ -635,7 +635,7 @@ func (window *Window) launchMenuView() {
 		icon.SetVAlign(gtk.ALIGN_START)
 		contentBox.PackStart(icon, false, true, 0)
 
-		label, err := gtk.LabelNew("System failed to pass pre-install checks.\n\n" + retErr.Error())
+		label, err := gtk.LabelNew(utils.Locale.Get("System failed to pass pre-install checks.") + "\n\n" + retErr.Error())
 		if err != nil {
 			log.Warning("Error creating label")
 			return
@@ -644,7 +644,7 @@ func (window *Window) launchMenuView() {
 		label.SetHAlign(gtk.ALIGN_END)
 		contentBox.PackStart(label, false, true, 0)
 
-		dialog, err := common.CreateDialogOneButton(contentBox, "System Check Failed", utils.Locale.Get("EXIT"), "button-cancel")
+		dialog, err := common.CreateDialogOneButton(contentBox, utils.Locale.Get("System Check Failed"), utils.Locale.Get("EXIT"), "button-cancel")
 		if err != nil {
 			log.Warning("Error creating dialog")
 			return

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -483,3 +483,18 @@ msgstr "Installation failed."
 
 msgid "Network is not working."
 msgstr "Network is not working."
+
+msgid "System failed to pass pre-install checks."
+msgstr "System failed to pass pre-install checks."
+
+msgid "System Check Failed"
+msgstr "System Check Failed"
+
+msgid "Unable to read /proc/cpuinfo"
+msgstr "Unable to read /proc/cpuinfo"
+
+msgid "Missing CPU feature: "
+msgstr "Missing CPU feature: "
+
+msgid "Failed to find EFI firmware"
+msgstr "Failed to find EFI firmware"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -483,3 +483,18 @@ msgstr "Instalación fallida."
 
 msgid "Network is not working."
 msgstr "La red no está funcionando."
+
+msgid "System failed to pass pre-install checks."
+msgstr "El sistema no pasó las comprobaciones previas a la instalación."
+
+msgid "System Check Failed"
+msgstr "Comprobación del sistema fallida"
+
+msgid "Unable to read /proc/cpuinfo"
+msgstr "No puede leer /proc/cpuinfo"
+
+msgid "Missing CPU feature: "
+msgstr "Característica de la CPU que falta: "
+
+msgid "Failed to find EFI firmware"
+msgstr "Error al encontrar el firmware EFI"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -483,3 +483,18 @@ msgstr "安装失败。"
 
 msgid "Network is not working."
 msgstr "网络无法正常工作。"
+
+msgid "System failed to pass pre-install checks."
+msgstr "系统无法通过安装前检查。"
+
+msgid "System Check Failed"
+msgstr "系统检查失败"
+
+msgid "Unable to read /proc/cpuinfo"
+msgstr "无法读取 /proc/cpuinfo"
+
+msgid "Missing CPU feature: "
+msgstr "缺少CPU功能： "
+
+msgid "Failed to find EFI firmware"
+msgstr "无法找到EFI固件"

--- a/syscheck/syscheck.go
+++ b/syscheck/syscheck.go
@@ -12,24 +12,25 @@ import (
 	"strings"
 
 	"github.com/clearlinux/clr-installer/log"
+	"github.com/clearlinux/clr-installer/utils"
 )
 
 func getCPUFeature(feature string) error {
 	cpuInfo, err := ioutil.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		log.Error("Unable to read /proc/cpuinfo")
-		return errors.New("Unable to read /proc/cpuinfo")
+		return errors.New(utils.Locale.Get("Unable to read /proc/cpuinfo"))
 	}
 	if strings.Contains(string(cpuInfo), feature) {
 		return nil
 	}
 
-	return errors.New("Missing CPU feature: " + feature)
+	return errors.New(utils.Locale.Get("Missing CPU feature: ") + feature)
 }
 
 func getEFIExist() error {
 	if _, err := os.Stat("/sys/firmware/efi"); os.IsNotExist(err) {
-		return errors.New("Failed to find EFI firmware")
+		return errors.New(utils.Locale.Get("Failed to find EFI firmware"))
 	}
 
 	return nil

--- a/syscheck/syscheck.go
+++ b/syscheck/syscheck.go
@@ -36,7 +36,7 @@ func getEFIExist() error {
 }
 
 // RunSystemCheck checks compatibility for clear linux. (e.g. EFI firmware, CPU featureset)
-func RunSystemCheck() error {
+func RunSystemCheck(quiet bool) error {
 	log.Info("Running system compatibility checks.")
 
 	//Check the following CPU features from /proc/cpuinfo
@@ -49,33 +49,44 @@ func RunSystemCheck() error {
 		"ssse3",
 	}
 	for _, feature := range cpuFeatures {
-		fmt.Printf("Checking for required CPU feaure: %s", feature)
+		if !quiet {
+			fmt.Printf("Checking for required CPU feaure: %s", feature)
+		}
+
 		err := getCPUFeature(feature)
 		if err != nil {
-			fmt.Printf(" [*failed*]\n")
-			fmt.Println(err)
+			if !quiet {
+				fmt.Printf(" [*failed*]\n")
+				fmt.Println(err)
+			}
 			log.ErrorError(err)
 
 			return err
 		}
-
-		fmt.Println(" [success]")
+		if !quiet {
+			fmt.Println(" [success]")
+		}
 	}
 
 	//Check if we have EFI firmware
-	fmt.Printf("Checking for required EFI firmware")
+	if !quiet {
+		fmt.Printf("Checking for required EFI firmware")
+	}
 	err := getEFIExist()
 	if err != nil {
-		fmt.Printf(" [*failed*]\n")
-		fmt.Println(err)
+		if !quiet {
+			fmt.Printf(" [*failed*]\n")
+			fmt.Println(err)
+		}
 		log.ErrorError(err)
 
 		return err
 	}
 
-	fmt.Println(" [success]")
-	fmt.Println("Success: System is compatible")
-
+	if !quiet {
+		fmt.Println(" [success]")
+		fmt.Println("Success: System is compatible")
+	}
 	log.Info("Success: System is compatible")
 	return nil
 }

--- a/themes/style.css
+++ b/themes/style.css
@@ -160,3 +160,12 @@ window {
     background-image: none;
     background-color: #414449;
 }
+
+.dialog-warning {
+    background-image: none;
+    background-color: #414449;
+}
+
+.dialog-warning image {
+    color: #FDB814;
+}


### PR DESCRIPTION
Run syscheck and report errors after the user chooses their language. This fixes the problem of users booting on Legacy systems and installing on EFI systems to find their system will not boot.

Clear doesn't support Legacy booting beyond the live images, so just return an error and force exiting if EFI isn't found.
Same goes for CPU features, though initrd will refuse to boot if the user is using an ISO image.

Fixes Issue: #232

Changes proposed in this pull request:
- Add a syscheck run that executes after clicking 'next' on the localization menu 
- Add a localized dialog box to inform of failures in the chosen language
