### PR TITLE
network: Always copy /etc network files

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -72,6 +72,7 @@ type Args struct {
 	KeepImage               bool
 	KeepImageSet            bool
 	SystemCheck             bool
+	CopyNetwork             bool
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -259,6 +260,10 @@ func (args *Args) setCommandLineArgs() (err error) {
 
 	flag.BoolVar(
 		&args.SystemCheck, "system-check", false, "Verify current system is compatible with Clear Linux and exit",
+	)
+
+	flag.BoolVar(
+		&args.CopyNetwork, "copy-network", true, "Copy the network interface configuration files to target",
 	)
 
 	flag.ErrHelp = errors.New("Clear Linux Installer program")

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -53,6 +53,10 @@ func (gui *Gui) Run(md *model.SystemInstall, rootDir string, options args.Args) 
 	gui.model = md
 	gui.installReboot = false
 
+	// When using the Interactive Installer we always want to copy network
+	// configurations to the target system
+	gui.model.CopyNetwork = options.CopyNetwork
+
 	// Use dark theming if available to differentiate from other apps
 	st, err := gtk.SettingsGetDefault()
 	if err != nil {

--- a/network/network.go
+++ b/network/network.go
@@ -861,17 +861,22 @@ func CopyNetworkInterfaces(rootDir string) error {
 	systemNetworkPaths := []string{systemdNetworkdDir, networkManagerDir}
 
 	for _, systemNetworkPath := range systemNetworkPaths {
+		log.Debug("Checking network interfaces in %q to install to target", systemNetworkPath)
 		if _, err := os.Stat(systemNetworkPath); err != nil {
 			if os.IsNotExist(err) {
-				log.Info("No updated network interfaces in %q to install to target",
+				log.Debug("No updated network interfaces in %q to install to target",
 					systemNetworkPath)
-				return nil
+				continue
 			}
-			return errors.Wrap(err)
+			log.Warning("Issue check interface %q: %v", systemNetworkPath, errors.Wrap(err))
+			continue
 		}
 
 		if err := utils.CopyAllFiles(systemNetworkPath, rootDir); err != nil {
-			log.Warning("Failed to copy image Network configuration data")
+			log.Warning("Failed to copy image Network configuration data to %s", systemNetworkPath)
+		} else {
+			log.Info("Copied image Network configuration data to %s",
+				filepath.Join(rootDir, systemNetworkPath))
 		}
 	}
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -72,6 +72,10 @@ func (tui *Tui) Run(md *model.SystemInstall, rootDir string, options args.Args) 
 		return false, err
 	}
 
+	// When using the Interactive Installer we always want to copy network
+	// configurations to the target system
+	tui.model.CopyNetwork = options.CopyNetwork
+
 	clui.SetThemePath(themeDir)
 
 	if !clui.SetCurrentTheme("clr-installer") {


### PR DESCRIPTION
Fixes Issue: #233

Changes proposed in this pull request:
- Always copy network config during interactive install to target system
- Add command line option to avoid network copy.


