### PR TITLE
swupd: Allow scripts to ensure network changes

### DIFF
--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -191,7 +191,7 @@ func (s *SoftwareUpdater) VerifyWithBundles(version string, mirror string, bundl
 			"-m",
 			version,
 			"--force",
-			"--no-scripts",
+			"--no-boot-update",
 			"-B",
 		}...)
 


### PR DESCRIPTION
Fixes Issue: #380

Changes proposed in this pull request:
- Change from --no-scripts to --no-boot-update which will allow post install hooks of swupd to run for the target install.


