### PR TITLE
tui: Add error dialog on syscheck failures

### DIFF
--- a/tui/tui.go
+++ b/tui/tui.go
@@ -9,6 +9,7 @@ import (
 	"github.com/clearlinux/clr-installer/cmd"
 	"github.com/clearlinux/clr-installer/log"
 	"github.com/clearlinux/clr-installer/model"
+	"github.com/clearlinux/clr-installer/syscheck"
 	"github.com/clearlinux/clr-installer/utils"
 
 	"github.com/VladimirMarkelov/clui"
@@ -136,6 +137,22 @@ func (tui *Tui) Run(md *model.SystemInstall, rootDir string, options args.Args) 
 			log.ErrorError(paniced)
 		}
 	}()
+
+	// Run system check, if fail report error and exit
+	if retErr := syscheck.RunSystemCheck(true); retErr != nil {
+		msg := "System failed to pass pre-install checks." + "\n" +
+			retErr.Error() + "\n\n" +
+			"The application will now exit."
+
+		if dialog, err := CreateWarningDialogBox(msg); err == nil {
+			dialog.OnClose(func() {
+				clui.Stop()
+				log.ErrorError(retErr)
+			})
+		} else {
+			log.Warning("Failed to create warning dialog: %s", err)
+		}
+	}
 
 	clui.MainLoop()
 


### PR DESCRIPTION
Directly after TUI init, run the system check and report if there are
any failures, and force application exit.

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>

Fixes Issue: #232

Changes proposed in this pull request:
- Run syscheck when using the TUI front end
- If syscheck fails, report the failure to the user and exit application

