### PR TITLE
Fix progress output for ISO generation

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -409,13 +409,10 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 	prg.Success()
 
 	if model.MakeISO {
-		msg = "Generating ISO image"
-		prg = progress.NewLoop(msg)
-		log.Info(msg)
+		log.Info("Generating ISO image")
 		if err = generateISO(rootDir, model, options); err != nil {
 			log.ErrorError(err)
 		}
-		prg.Success()
 	}
 
 	msg = utils.Locale.Get("Installation completed")
@@ -762,9 +759,7 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 // generateISO creates an ISO image from the just created raw image
 func generateISO(rootDir string, md *model.SystemInstall, options args.Args) error {
 	var err error
-	msg := "Building ISO image"
-	prg := progress.NewLoop(msg)
-	log.Info(msg)
+	log.Info("Building ISO image")
 
 	if !md.LegacyBios {
 		for _, alias := range md.StorageAlias {
@@ -775,10 +770,8 @@ func generateISO(rootDir string, md *model.SystemInstall, options args.Args) err
 	} else {
 		err = fmt.Errorf("cannot create ISO images for configurations with LegacyBios enabled")
 		log.ErrorError(err)
-		prg.Failure()
 		return err
 	}
 
-	prg.Success()
 	return err
 }

--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -37,7 +37,7 @@ var (
 )
 
 func mkTmpDirs() error {
-	msg := "Creating directory trees"
+	msg := "Making temp directories for ISO creation"
 	prg := progress.NewLoop(msg)
 	log.Info(msg)
 	var err error
@@ -79,7 +79,7 @@ func mkTmpDirs() error {
 }
 
 func mkRootfs() error {
-	msg := "making rootfs squashfs"
+	msg := "Making squashfs of rootfs"
 	prg := progress.NewLoop(msg)
 	log.Info(msg)
 


### PR DESCRIPTION
The way this was coded was causing bugs in output when creating an ISO
image. The most obvious was the line "Cleaning up from ISO creation"
would be repeated a few times at the end of execution.

Having sub-progress loops doesn't make sense here, since the flow is
"task"->"completion status" not "task"->"subtask"->"sub
complete"->"task complete"

Also, the removed progress loops would fail to be printed anyways, so
removing them doesn't change progress output except for fixing this
bug.

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>

Changes proposed in this pull request:
- Remove a few spurious progress loops and reword some progress strings for clarity
- Removed progress items were bugged anyways and didn't print at all.

output before patch:
```
Saving the installation results [success]
Creating directory trees [success]
making rootfs squashfs [success]
Installing the base system for initrd [success]
Creating and installing init script to initrd [success]
Building initrd image [success]
Building efiboot image [success]
Setting up BIOS boot with isolinux [success]
Building ISO [success]
Cleaning up from ISO creation [success]
Cleaning up from ISO creation [success]
Cleaning up from ISO creation [success]
Installation completed [success]
```

after:
```
Saving the installation results [success]
Making temp directories for ISO creation [success]
Making squashfs of rootfs [success]
Installing the base system for initrd [success]
Creating and installing init script to initrd [success]
Building initrd image [success]
Building efiboot image [success]
Setting up BIOS boot with isolinux [success]
Building ISO [success]
Cleaning up from ISO creation [success]
Installation completed [success]
```