### PR TITLE
Scan Media in the background

### DIFF
--- a/gui/pages/init.go
+++ b/gui/pages/init.go
@@ -63,9 +63,13 @@ type Controller interface {
 	SetButtonVisible(flags Button, enabled bool)
 	GetRootDir() string
 	GetOptions() args.Args
-	GetScanInfo() ScanInfo
-	GetScannedMedia() []*storage.BlockDevice
-	SetScannedMedia([]*storage.BlockDevice)
+
+	// Getters and Setters for ScanInfo
+	GetScanChannel() chan bool
+	GetScanDone() bool
+	SetScanDone(bool)
+	GetScanMedia() []*storage.BlockDevice
+	SetScanMedia([]*storage.BlockDevice)
 }
 
 // ScanInfo holds the information related to scanning the media

--- a/gui/pages/init.go
+++ b/gui/pages/init.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/clearlinux/clr-installer/args"
 	"github.com/clearlinux/clr-installer/log"
+	"github.com/clearlinux/clr-installer/storage"
 )
 
 // Button allows us to flag up different buttons
@@ -62,6 +63,16 @@ type Controller interface {
 	SetButtonVisible(flags Button, enabled bool)
 	GetRootDir() string
 	GetOptions() args.Args
+	GetScanInfo() ScanInfo
+	GetScannedMedia() []*storage.BlockDevice
+	SetScannedMedia([]*storage.BlockDevice)
+}
+
+// ScanInfo holds the information related to scanning the media
+type ScanInfo struct {
+	Channel chan bool              // Bool channel for scanning media
+	Done    bool                   // Used to check if scanning has been done at least once
+	Media   []*storage.BlockDevice // Scanned media
 }
 
 const (

--- a/gui/window.go
+++ b/gui/window.go
@@ -154,7 +154,6 @@ func NewWindow(model *model.SystemInstall, rootDir string, options args.Args) (*
 			log.Warning("Error scanning media %s", err.Error())
 		}
 		window.scanInfo.Channel <- true
-		window.scanInfo.Done = true
 	}()
 
 	return window, nil
@@ -752,18 +751,28 @@ func (window *Window) GetRootDir() string {
 	return window.rootDir
 }
 
-// GetScanInfo returns the information related to scanning the media
-func (window *Window) GetScanInfo() pages.ScanInfo {
-	return window.scanInfo
+// GetScanChannel is the getter for ScanInfo Channel
+func (window *Window) GetScanChannel() chan bool {
+	return window.scanInfo.Channel
 }
 
-// GetScannedMedia returns the scanned media
-func (window *Window) GetScannedMedia() []*storage.BlockDevice {
+// GetScanDone is the getter for ScanInfo Done
+func (window *Window) GetScanDone() bool {
+	return window.scanInfo.Done
+}
+
+// SetScanDone is the setter for ScanInfo Done
+func (window *Window) SetScanDone(done bool) {
+	window.scanInfo.Done = done
+}
+
+// GetScanMedia is the getter for ScanInfo Media
+func (window *Window) GetScanMedia() []*storage.BlockDevice {
 	return window.scanInfo.Media
 }
 
-// SetScannedMedia sets the scanned media
-func (window *Window) SetScannedMedia(scannedMedia []*storage.BlockDevice) {
+// SetScanMedia is the setter for ScanInfo Media
+func (window *Window) SetScanMedia(scannedMedia []*storage.BlockDevice) {
 	window.scanInfo.Media = scannedMedia
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -708,7 +708,7 @@ func updateBlockDevices(toBeUpdated *BlockDevice, updates []*BlockDevice) {
 	}
 }
 
-// RescanBlockDevices Clear current list available block devices and rescans
+// RescanBlockDevices clears current list available block devices and rescans
 func RescanBlockDevices(userDefined []*BlockDevice) ([]*BlockDevice, error) {
 	avBlockDevices = nil
 


### PR DESCRIPTION
Fixes Issue: #391

In order to avoid delay in loading the installer, scan the media in the
background as a separate go routine.


