### PR TITLE
Swupd cert

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -48,6 +48,7 @@ type Args struct {
 	CryptPassFile           string
 	SwupdMirror             string
 	SwupdStateDir           string
+	SwupdCertPath           string
 	SwupdStateClean         bool
 	SwupdFormat             string
 	SwupdContentURL         string
@@ -158,6 +159,10 @@ func (args *Args) setCommandLineArgs() (err error) {
 
 	flag.StringVar(
 		&args.SwupdStateDir, "swupd-state", args.SwupdStateDir, "Swupd state-dir",
+	)
+
+	flag.StringVar(
+		&args.SwupdCertPath, "swupd-cert", args.SwupdCertPath, "Swupd --certpath",
 	)
 
 	flag.BoolVar(

--- a/args/args.go
+++ b/args/args.go
@@ -154,11 +154,11 @@ func (args *Args) setCommandLineArgs() (err error) {
 	)
 
 	flag.StringVar(
-		&args.SwupdMirror, "swupd-mirror", args.SwupdMirror, "Swupd Installation mirror URL",
+		&args.SwupdMirror, "swupd-mirror", args.SwupdMirror, "Swupd --url; sets target mirror",
 	)
 
 	flag.StringVar(
-		&args.SwupdStateDir, "swupd-state", args.SwupdStateDir, "Swupd state-dir",
+		&args.SwupdStateDir, "swupd-state", args.SwupdStateDir, "Swupd --statedir",
 	)
 
 	flag.StringVar(

--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -123,7 +123,7 @@ func mkInitrd(version string, model *model.SystemInstall, options args.Args) err
 	sw := swupd.New(tmpPaths[clrInitrd], options)
 
 	/* Should install the overridden CoreBundles above (eg. os-core only) */
-	if err := sw.Verify(version, model.SwupdMirror, true); err != nil {
+	if err := sw.VerifyWithBundles(version, model.SwupdMirror, []string{}); err != nil {
 		prg.Failure()
 		return err
 	}

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -329,26 +329,6 @@ func (s *SoftwareUpdater) VerifyWithBundles(version string, mirror string, bundl
 	return nil
 }
 
-// Update executes the "swupd update" operation
-func (s *SoftwareUpdater) Update() error {
-	args := []string{
-		"swupd",
-		"update",
-		"--keepcache",
-		fmt.Sprintf("--path=%s", s.rootDir),
-		fmt.Sprintf("--statedir=%s", s.stateDir),
-	}
-
-	log.Info("Checking for swupd updates")
-
-	err := cmd.RunAndLog(args...)
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	return nil
-}
-
 // DisableUpdate executes the "systemctl" to disable auto update operation
 // "swupd autoupdate" currently does not --path
 // See Issue https://github.com/clearlinux/swupd-client/issues/527
@@ -540,33 +520,6 @@ func parseSwupdMirror(data []byte) (string, error) {
 	}
 
 	return string(match[1]), nil
-}
-
-// BundleAdd executes the "swupd bundle-add" operation for a single bundle
-func (s *SoftwareUpdater) BundleAdd(bundle string) error {
-	args := []string{
-		"swupd",
-		"bundle-add",
-	}
-
-	if s.skipDiskSpaceCheck {
-		args = append(args, "--skip-diskspace-check")
-	}
-
-	args = s.setExtraFlags(args)
-
-	args = append(args,
-		fmt.Sprintf("--path=%s", s.rootDir),
-		fmt.Sprintf("--statedir=%s", s.stateDir),
-		bundle,
-	)
-
-	err := cmd.RunAndLog(args...)
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	return nil
 }
 
 // LoadBundleList loads the bundle definitions

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -40,6 +40,7 @@ var (
 type SoftwareUpdater struct {
 	rootDir            string
 	stateDir           string
+	certPath           string
 	format             string
 	contentURL         string
 	versionURL         string
@@ -152,6 +153,7 @@ func New(rootDir string, options args.Args) *SoftwareUpdater {
 	return &SoftwareUpdater{
 		rootDir,
 		stateDir,
+		options.SwupdCertPath,
 		options.SwupdFormat,
 		options.SwupdContentURL,
 		options.SwupdVersionURL,
@@ -160,6 +162,10 @@ func New(rootDir string, options args.Args) *SoftwareUpdater {
 }
 
 func (s *SoftwareUpdater) setExtraFlags(args []string) []string {
+	if s.certPath != "" {
+		args = append(args, fmt.Sprintf("--certpath=%s", s.certPath))
+	}
+
 	if s.format != "" {
 		args = append(args, fmt.Sprintf("--format=%s", s.format))
 	}

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -282,27 +282,28 @@ func (s *SoftwareUpdater) VerifyWithBundles(version string, mirror string, bundl
 			"--force",
 			"--no-boot-update",
 			"--json-output",
-			"-B",
 		}...)
 
-	// Remove the 'os-core' bundle as it is already
-	// installed and will cause a failure
-	allBundles := []string{}
-	for _, bundle := range CoreBundles {
-		if bundle != "os-core" {
+	if len(bundles) > 0 {
+		// Remove the 'os-core' bundle as it is already
+		// installed and will cause a failure
+		allBundles := []string{}
+		for _, bundle := range CoreBundles {
+			if bundle != "os-core" {
+				allBundles = append(allBundles, bundle)
+			}
+		}
+		// Additional bundles
+		for _, bundle := range bundles {
+			if IsCoreBundle(bundle) {
+				log.Debug("Bundle %s was already installed with the core bundles, skipping", bundle)
+				continue
+			}
 			allBundles = append(allBundles, bundle)
 		}
-	}
-	// Additional bundles
-	for _, bundle := range bundles {
-		if IsCoreBundle(bundle) {
-			log.Debug("Bundle %s was already installed with the core bundles, skipping", bundle)
-			continue
-		}
-		allBundles = append(allBundles, bundle)
-	}
 
-	args = append(args, strings.Join(allBundles, ","))
+		args = append(args, "-B", strings.Join(allBundles, ","))
+	}
 
 	m := Message{}
 	err := cmd.RunAndProcessOutput(m, args...)

--- a/tests/coverage-curr-status
+++ b/tests/coverage-curr-status
@@ -8,6 +8,7 @@ ok  	github.com/clearlinux/clr-installer/encrypt	0.026s	coverage: 85.0% of state
 ok  	github.com/clearlinux/clr-installer/errors	0.014s	coverage: 100.0% of statements
 ?   	github.com/clearlinux/clr-installer/frontend	[no test files]
 ok  	github.com/clearlinux/clr-installer/hostname	0.033s	coverage: 100.0% of statements
+?   	github.com/clearlinux/clr-installer/isoutils	[no test files]
 ?   	github.com/clearlinux/clr-installer/kernel	[no test files]
 ?   	github.com/clearlinux/clr-installer/keyboard	[no test files]
 ?   	github.com/clearlinux/clr-installer/language	[no test files]
@@ -15,10 +16,11 @@ ok  	github.com/clearlinux/clr-installer/hostname	0.033s	coverage: 100.0% of sta
 ok  	github.com/clearlinux/clr-installer/log	0.163s	coverage: 100.0% of statements
 ?   	github.com/clearlinux/clr-installer/massinstall	[no test files]
 ok  	github.com/clearlinux/clr-installer/model	0.013s	coverage: 92.0% of statements
-ok  	github.com/clearlinux/clr-installer/network	0.734s	coverage: 20.0% of statements
+ok  	github.com/clearlinux/clr-installer/network	0.734s	coverage: 23.0% of statements
 ?   	github.com/clearlinux/clr-installer/progress	[no test files]
-ok  	github.com/clearlinux/clr-installer/storage	0.026s	coverage: 27.0% of statements
-ok  	github.com/clearlinux/clr-installer/swupd	0.017s	coverage: 13.0% of statements
+ok  	github.com/clearlinux/clr-installer/storage	0.026s	coverage: 32.0% of statements
+ok  	github.com/clearlinux/clr-installer/swupd	0.017s	coverage: 14.0% of statements
+?   	github.com/clearlinux/clr-installer/syscheck	[no test files]
 ok  	github.com/clearlinux/clr-installer/telemetry	0.317s	coverage: 35.6% of statements
 ?   	github.com/clearlinux/clr-installer/timezone	[no test files]
 ?   	github.com/clearlinux/clr-installer/tui	[no test files]


### PR DESCRIPTION
Fixes Issue: #228

Changes proposed in this pull request:
- Add support for swupd --certpath
- Removed deprecated code

Requires the new release of swupd-client (>= 4.0.0) before the merge.


