### PR TITLE
isoutils: Fix output after swupd updates

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -114,7 +114,8 @@ func mkRootfs() error {
 
 func mkInitrd(version string, model *model.SystemInstall, options args.Args) error {
 	msg := "Installing the base system for initrd"
-	prg := progress.NewLoop(msg)
+	var prg progress.Progress
+
 	log.Info(msg)
 
 	var err error
@@ -122,12 +123,13 @@ func mkInitrd(version string, model *model.SystemInstall, options args.Args) err
 	options.SwupdFormat = "staging"
 	sw := swupd.New(tmpPaths[clrInitrd], options)
 
-	/* Should install the overridden CoreBundles above (eg. os-core only) */
+	/* Install os-core only as initrd */
 	if err := sw.VerifyWithBundles(version, model.SwupdMirror, []string{}); err != nil {
+		prg = progress.NewLoop(msg)
 		prg.Failure()
 		return err
 	}
-
+	prg = progress.NewLoop(msg)
 	prg.Success()
 	return err
 }


### PR DESCRIPTION
When the swupd internal API changed, it broke iso production output -
there were progress 'subtasks' again. This commit fixes the output for ISO
creation by moving progress creation until after swupd is finished.

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>

Changes proposed in this pull request:
- Don't create a progress until Swupd is done. Not ideal, but still communicates the steps being taken and no longer breaks output

Before:
```
Making squashfs of rootfs [success]
Resolving OS versions [success]initrd [\]
Cleaning up download directory [success]
Downloading required manifests [success]
Resolving files that need to be installed [success]
Downloading required packs [success]alled [\]
Verifying files integrity [success]
Downloading missing files [success]
Installing base OS and configured bundles [success]
Installing base OS and configured bundles [success]
Creating and installing init script to initrd [success]
```

After:
```
Making squashfs of rootfs [success]
Resolving OS versions [success]
Cleaning up download directory [success]
Downloading required manifests [success]
Resolving files that need to be installed [success]
Downloading required packs [success]
Verifying files integrity [success]
Downloading missing files [success]
Installing base OS and configured bundles [success]
Installing the base system for initrd [success]
Creating and installing init script to initrd [success]
```