### PR TITLE
Enable Telemetry using buttons

### DIFF
--- a/gui/pages/init.go
+++ b/gui/pages/init.go
@@ -60,7 +60,6 @@ type Page interface {
 type Controller interface {
 	ActivatePage(Page)
 	SetButtonState(flags Button, enabled bool)
-	SetButtonVisible(flags Button, enabled bool)
 	GetRootDir() string
 	GetOptions() args.Args
 

--- a/gui/pages/telemetry.go
+++ b/gui/pages/telemetry.go
@@ -16,8 +16,8 @@ type Telemetry struct {
 	model      *model.SystemInstall
 	controller Controller
 	box        *gtk.Box
-	check      *gtk.CheckButton
 	didConfirm bool
+	firstLoad  bool // Keeps track if the page was loaded for the first time.
 }
 
 // NewTelemetryPage returns a new TelemetryPage
@@ -39,19 +39,12 @@ func NewTelemetryPage(controller Controller, model *model.SystemInstall) (Page, 
 	label.SetMarginBottom(20)
 	box.PackStart(label, true, false, 0)
 
-	check, err := gtk.CheckButtonNewWithLabel(utils.Locale.Get("Enable Telemetry"))
-	if err != nil {
-		return nil, err
-	}
-	check.SetHAlign(gtk.ALIGN_CENTER)
-	box.PackStart(check, true, false, 0)
-
 	return &Telemetry{
 		controller: controller,
 		model:      model,
 		box:        box,
-		check:      check,
 		didConfirm: false,
+		firstLoad:  true,
 	}, nil
 }
 
@@ -93,15 +86,18 @@ func (page *Telemetry) GetTitle() string {
 // StoreChanges will store this pages changes into the model
 func (page *Telemetry) StoreChanges() {
 	page.didConfirm = true
-	page.model.EnableTelemetry(page.check.GetActive())
-	page.controller.SetButtonVisible(ButtonCancel, true)
+	page.model.EnableTelemetry(true)
 }
 
 // ResetChanges will reset this page to match the model
 func (page *Telemetry) ResetChanges() {
-	page.controller.SetButtonVisible(ButtonCancel, false)
-	page.controller.SetButtonState(ButtonConfirm, true)
-	page.check.SetActive(page.model.IsTelemetryEnabled())
+	if page.firstLoad {
+		page.didConfirm = false
+		page.firstLoad = false
+	} else {
+		page.didConfirm = true
+	}
+	page.model.EnableTelemetry(false)
 }
 
 // GetConfiguredValue returns our current config

--- a/gui/pages/telemetry.go
+++ b/gui/pages/telemetry.go
@@ -56,57 +56,57 @@ func NewTelemetryPage(controller Controller, model *model.SystemInstall) (Page, 
 }
 
 // IsRequired will return true as we always need a Telemetry
-func (t *Telemetry) IsRequired() bool {
+func (page *Telemetry) IsRequired() bool {
 	return true
 }
 
 // IsDone checks if all the steps are completed
-func (t *Telemetry) IsDone() bool {
-	return t.didConfirm
+func (page *Telemetry) IsDone() bool {
+	return page.didConfirm
 }
 
 // GetID returns the ID for this page
-func (t *Telemetry) GetID() int {
+func (page *Telemetry) GetID() int {
 	return PageIDTelemetry
 }
 
 // GetIcon returns the icon for this page
-func (t *Telemetry) GetIcon() string {
+func (page *Telemetry) GetIcon() string {
 	return "network-transmit-receive"
 }
 
 // GetRootWidget returns the root embeddable widget for this page
-func (t *Telemetry) GetRootWidget() gtk.IWidget {
-	return t.box
+func (page *Telemetry) GetRootWidget() gtk.IWidget {
+	return page.box
 }
 
 // GetSummary will return the summary for this page
-func (t *Telemetry) GetSummary() string {
+func (page *Telemetry) GetSummary() string {
 	return utils.Locale.Get("Telemetry")
 }
 
 // GetTitle will return the title for this page
-func (t *Telemetry) GetTitle() string {
+func (page *Telemetry) GetTitle() string {
 	return utils.Locale.Get("Enable Telemetry")
 }
 
 // StoreChanges will store this pages changes into the model
-func (t *Telemetry) StoreChanges() {
-	t.didConfirm = true
-	t.model.EnableTelemetry(t.check.GetActive())
-	t.controller.SetButtonVisible(ButtonCancel, true)
+func (page *Telemetry) StoreChanges() {
+	page.didConfirm = true
+	page.model.EnableTelemetry(page.check.GetActive())
+	page.controller.SetButtonVisible(ButtonCancel, true)
 }
 
 // ResetChanges will reset this page to match the model
-func (t *Telemetry) ResetChanges() {
-	t.controller.SetButtonVisible(ButtonCancel, false)
-	t.controller.SetButtonState(ButtonConfirm, true)
-	t.check.SetActive(t.model.IsTelemetryEnabled())
+func (page *Telemetry) ResetChanges() {
+	page.controller.SetButtonVisible(ButtonCancel, false)
+	page.controller.SetButtonState(ButtonConfirm, true)
+	page.check.SetActive(page.model.IsTelemetryEnabled())
 }
 
 // GetConfiguredValue returns our current config
-func (t *Telemetry) GetConfiguredValue() string {
-	if t.model.IsTelemetryEnabled() {
+func (page *Telemetry) GetConfiguredValue() string {
+	if page.model.IsTelemetryEnabled() {
 		return utils.Locale.Get("Enabled")
 	}
 	return utils.Locale.Get("Disabled")

--- a/gui/window.go
+++ b/gui/window.go
@@ -516,15 +516,17 @@ func (window *Window) pageClosed(applied bool) {
 	window.buttons.stack.SetVisibleChildName("primary")
 }
 
-// ActivatePage displays the page
+// ActivatePage customizes common widgets and displays the page
 func (window *Window) ActivatePage(page pages.Page) {
 	window.menu.currentPage = page
 	id := page.GetID()
 
-	if id == pages.PageIDWelcome { // Welcome Page
+	// Customize common widgets based on the page being loaded
+	switch id {
+	case pages.PageIDWelcome:
 		window.banner.Show()
 		window.buttons.stack.SetVisibleChildName("welcome")
-	} else if id == pages.PageIDInstall { // Install Page
+	case pages.PageIDInstall:
 		window.menu.switcher.Hide()
 		window.banner.Show()
 		window.banner.labelText.SetMarkup(GetThankYouMessage())
@@ -538,12 +540,23 @@ func (window *Window) ActivatePage(page pages.Page) {
 		} else {
 			sc.AddClass("button-confirm")
 		}
-		window.SetButtonState(pages.ButtonQuit, false)
-	} else {
+		window.buttons.quit.SetSensitive(false)
+	case pages.PageIDTelemetry:
 		window.menu.switcher.Hide()
 		window.banner.Hide()
 		window.buttons.stack.SetVisibleChildName("secondary")
-		window.SetButtonState(pages.ButtonConfirm, false)
+		window.buttons.confirm.SetSensitive(true)
+		window.buttons.confirm.SetCanDefault(true)
+		window.buttons.confirm.GrabDefault()
+		window.buttons.confirm.SetLabel(utils.Locale.Get("YES"))
+		window.buttons.cancel.SetLabel(utils.Locale.Get("NO"))
+	default:
+		window.menu.switcher.Hide()
+		window.banner.Hide()
+		window.buttons.stack.SetVisibleChildName("secondary")
+		window.buttons.confirm.SetSensitive(false)
+		window.buttons.confirm.SetLabel(utils.Locale.Get("CONFIRM"))
+		window.buttons.cancel.SetLabel(utils.Locale.Get("CANCEL"))
 	}
 
 	// Allow page to take control now
@@ -574,31 +587,6 @@ func (window *Window) SetButtonState(flags pages.Button, enabled bool) {
 		}
 		if flags&pages.ButtonExit == pages.ButtonExit {
 			window.buttons.exit.SetSensitive(enabled)
-		}
-	}
-}
-
-// SetButtonVisible is called by the pages to view/hide certain buttons.
-func (window *Window) SetButtonVisible(flags pages.Button, visible bool) {
-	if window.menu.currentPage.GetID() != pages.PageIDWelcome {
-		if flags&pages.ButtonCancel == pages.ButtonCancel {
-			window.buttons.cancel.SetVisible(visible)
-		}
-		if flags&pages.ButtonConfirm == pages.ButtonConfirm {
-			window.buttons.confirm.SetVisible(visible)
-		}
-		if flags&pages.ButtonQuit == pages.ButtonQuit {
-			window.buttons.quit.SetVisible(visible)
-		}
-		if flags&pages.ButtonBack == pages.ButtonBack {
-			window.buttons.back.SetVisible(visible)
-		}
-	} else {
-		if flags&pages.ButtonNext == pages.ButtonNext {
-			window.buttons.next.SetVisible(visible)
-		}
-		if flags&pages.ButtonExit == pages.ButtonExit {
-			window.buttons.exit.SetVisible(visible)
 		}
 	}
 }

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -523,3 +523,9 @@ msgstr "Verifying files integrity"
 
 msgid "Downloading missing files"
 msgstr "Downloading missing files"
+
+msgid "YES"
+msgstr "YES"
+
+msgid "NO"
+msgstr "NO"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -523,3 +523,9 @@ msgstr "Verificando la integridad de archivos"
 
 msgid "Downloading missing files"
 msgstr "Descargando los archivos faltantes"
+
+msgid "YES"
+msgstr "SÍ"
+
+msgid "NO"
+msgstr "NO"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -523,3 +523,9 @@ msgstr "验证文件完整性"
 
 msgid "Downloading missing files"
 msgstr "下载丢失的文件"
+
+msgid "YES"
+msgstr "是"
+
+msgid "NO"
+msgstr "没有"

--- a/tui/telemetry.go
+++ b/tui/telemetry.go
@@ -72,11 +72,11 @@ func newTelemetryPage(tui *Tui) (Page, error) {
 		noticeLbl.SetMultiline(true)
 	}
 
-	page.backBtn.SetTitle("No, thanks")
+	page.backBtn.SetTitle("No")
 	page.backBtn.SetSize(12, 1)
 
-	page.confirmBtn.SetTitle("Yes, enable telemetry!!")
-	page.confirmBtn.SetSize(25, 1)
+	page.confirmBtn.SetTitle("Yes")
+	page.confirmBtn.SetSize(12, 1)
 
 	return page, nil
 }


### PR DESCRIPTION
**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #442
- Instead of check box, use buttons to enable/disable telemetry.
- Used simple labels "NO" and "YES" instead of "No, opt-out" and "Yes, opt-in" for precise language translations.



