### PR TITLE
gui: Reformat info label during installation

### DIFF
--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -536,3 +536,13 @@ msgstr "YES"
 
 msgid "NO"
 msgstr "NO"
+
+msgid "Installation in progress."
+msgstr "Installation in progress."
+
+msgid "Installation successful."
+msgstr "Installation successful."
+
+#, c-format
+msgid "See %s for details."
+msgstr "See %s for details."

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -536,3 +536,13 @@ msgstr "SÍ"
 
 msgid "NO"
 msgstr "NO"
+
+msgid "Installation in progress."
+msgstr "Instalación en curso."
+
+msgid "Installation successful."
+msgstr "Instalación exitosa."
+
+#, c-format
+msgid "See %s for details."
+msgstr "Ver %s para más detalles."

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -536,3 +536,13 @@ msgstr "是"
 
 msgid "NO"
 msgstr "没有"
+
+msgid "Installation in progress."
+msgstr "安装正在进行中。"
+
+msgid "Installation successful."
+msgstr "安装成功。"
+
+#, c-format
+msgid "See %s for details."
+msgstr "请参阅 %s 了解详情。"

--- a/themes/style.css
+++ b/themes/style.css
@@ -141,9 +141,14 @@ window {
 }
 
 .label-warning {
-    font-size: 95%;
+    font-size: 110%;
     font-style: italic;
     color: #FDB814;
+}
+
+.label-info {
+    font-size: 110%;
+    font-style: italic;
 }
 
 .label-entry {


### PR DESCRIPTION
Fixes #422.
- Added an info label during installation that indicates success/failure.
- Text wraps the label and makes it selectable.
- Removes the error details from the info msg. Instead, includes the path to the log file.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>



