### PR TITLE
user: Allow upper case and periods in login name

### DIFF
--- a/gui/pages/user_add.go
+++ b/gui/pages/user_add.go
@@ -81,7 +81,7 @@ func NewUserAddPage(controller Controller, model *model.SystemInstall) (Page, er
 
 	// Login
 	page.login, page.loginWarning, err = page.setSimilarWidgets(utils.Locale.Get("Login")+" *",
-		utils.Locale.Get("Must start with letter. Can use numbers, - and _. Max %d characters.", user.MaxLoginLength),
+		utils.Locale.Get("Must begin with a letter. You can use letters, numbers, hyphens, underscores, and periods. Up to %d characters.", user.MaxLoginLength),
 		user.MaxLoginLength)
 	if err != nil {
 		return nil, err

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -177,8 +177,8 @@ msgid "Must start with letter. Can use numbers, commas, - and _. Max %d characte
 msgstr "Must start with letter. Can use numbers, commas, - and _. Max %d characters."
 
 #, c-format
-msgid "Must start with letter. Can use numbers, - and _. Max %d characters."
-msgstr "Must start with letter. Can use numbers, - and _. Max %d characters."
+msgid "Must begin with a letter. You can use letters, numbers, hyphens, underscores, and periods. Up to %d characters."
+msgstr "Must begin with a letter. You can use letters, numbers, hyphens, underscores, and periods. Up to %d characters."
 
 #, c-format
 msgid "Min %d and Max %d characters."
@@ -237,8 +237,8 @@ msgstr "Login is required"
 msgid "Login maximum length is %d"
 msgstr "Login maximum length is %d"
 
-msgid "Login must contain only numbers, lower case letters, - or _"
-msgstr "Login must contain only numbers, lower case letters, - or _"
+msgid "Login must contain only numbers, letters, -, _ or ."
+msgstr "Login must contain only numbers, letters, -, _ or ."
 
 msgid "Password is required"
 msgstr "Password is required"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -177,8 +177,8 @@ msgid "Must start with letter. Can use numbers, commas, - and _. Max %d characte
 msgstr "Debe comenzar con una letra. Puede contener números, comas, - y _. Máx. %d caracteres."
 
 #, c-format
-msgid "Must start with letter. Can use numbers, - and _. Max %d characters."
-msgstr "Debe comenzar con una letra. Puede contener números, - y _. Máx. %d caracteres."
+msgid "Must begin with a letter. You can use letters, numbers, hyphens, underscores, and periods. Up to %d characters."
+msgstr "Debe comenzar con una carta. Puede usar letras, números, guiones, guiones y puntos. Hasta %d caracteres."
 
 #, c-format
 msgid "Min %d and Max %d characters."
@@ -237,8 +237,8 @@ msgstr "Debe iniciar sesión."
 msgid "Login maximum length is %d"
 msgstr "La extensión máxima del inicio de sesión debe ser de %d."
 
-msgid "Login must contain only numbers, lower case letters, - or _"
-msgstr "El inicio de sesión solo debe contener números, letras minúsculas, - o _."
+msgid "Login must contain only numbers, letters, -, _ or ."
+msgstr "El inicio de sesión debe contener solo números, letras, -, _ o ."
 
 msgid "Password is required"
 msgstr "Se requiere una contraseña."

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -177,8 +177,8 @@ msgid "Must start with letter. Can use numbers, commas, - and _. Max %d characte
 msgstr "必须以字母开头。可以使用数字、逗号、连字符和下划线。最多 %d 个字符。"
 
 #, c-format
-msgid "Must start with letter. Can use numbers, - and _. Max %d characters."
-msgstr "必须以字母开头。可以使用数字、连字符和下划线。最多 %d 个字符。"
+msgid "Must begin with a letter. You can use letters, numbers, hyphens, underscores, and periods. Up to %d characters."
+msgstr "必须以一封信开头。您可以使用字母、数字、连字符、下划线和句点。最多 %d 字符。"
 
 #, c-format
 msgid "Min %d and Max %d characters."
@@ -237,8 +237,8 @@ msgstr "需要登录"
 msgid "Login maximum length is %d"
 msgstr "登录名最大长度为 %d"
 
-msgid "Login must contain only numbers, lower case letters, - or _"
-msgstr "登录名必须仅包含数字、小写字母、连字符和下划线"
+msgid "Login must contain only numbers, letters, -, _ or ."
+msgstr "登录名必须仅包含数字、字母、连字符、下划线或句点。"
 
 msgid "Password is required"
 msgstr "需要密码"

--- a/user/user.go
+++ b/user/user.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	usernameExp     = regexp.MustCompile("^([a-zA-Z]+[0-9a-zA-Z-_ ,'.]*|)$")
-	loginExp        = regexp.MustCompile("^[a-z]+[0-9a-z-_]*$")
+	loginExp        = regexp.MustCompile("^[a-zA-Z]+[0-9a-zA-Z-_.]*$")
 	sysDefaultUsers = []string{}
 )
 
@@ -441,7 +441,7 @@ func IsValidLogin(login string) (bool, string) {
 	}
 
 	if !loginExp.MatchString(login) {
-		return false, utils.Locale.Get("Login must contain only numbers, lower case letters, - or _")
+		return false, utils.Locale.Get("Login must contain only numbers, letters, -, _ or .")
 	}
 
 	return true, ""


### PR DESCRIPTION
Fixes Issue: #432

Changes proposed in this pull request:
- Re-enable the use of upper case letters for login name
- Now allow dot `.` in the login name



