### PR TITLE
telemetry: Include hypervisor to telemetry payload

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -695,7 +695,12 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 	}
 
 	var payload string
-	confBytes, bytesErr = yaml.Marshal(cleanModel)
+	hypervisor := md.Telemetry.RunningEnvironment()
+	extendedModel := model.SystemUsage{
+		InstallModel: cleanModel,
+		Hypervisor:   hypervisor,
+	}
+	confBytes, bytesErr = yaml.Marshal(extendedModel)
 	if bytesErr != nil {
 		log.Error("Failed to generate a sanitized data (%v)", bytesErr)
 		errMsgs = append(errMsgs, "Failed to generate a sanitized YAML file")

--- a/model/model.go
+++ b/model/model.go
@@ -86,6 +86,12 @@ type SystemInstall struct {
 	KeepImage         bool                   `yaml:"keepImage,omitempty,flow"`
 }
 
+// SystemUsage is used to include additional information into the telemetry payload
+type SystemUsage struct {
+	InstallModel SystemInstall `yaml:",inline"`
+	Hypervisor   string        `yaml:"hypervisor,omitempty,flow"`
+}
+
 // InstallHook is a commands to be executed in a given point of the install process
 type InstallHook struct {
 	Chroot bool   `yaml:"chroot,omitempty,flow"`

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -12,9 +12,11 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/clearlinux/clr-installer/cmd"
@@ -55,6 +57,9 @@ is collected.
 
 	maxPayload = 8 * 1024
 	baseClass  = "org.clearlinux/clr-installer"
+
+	// Detect hypervisor if running in VM
+	envCmd = "/usr/bin/systemd-detect-virt"
 )
 
 var (
@@ -409,4 +414,16 @@ func (tl *Telemetry) LogRecord(class string, severity int, payload string) error
 	}
 
 	return nil
+}
+
+// RunningEnvironment returns the name of the hypervisor if running in a
+// virtual machine, otherwise none
+func (tl *Telemetry) RunningEnvironment() string {
+
+	out, err := exec.Command(envCmd).Output()
+	if err == nil {
+		return strings.TrimRight(string(out), "\n")
+	}
+
+	return "none"
 }

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -412,3 +412,10 @@ func TestConfigNotChanged(t *testing.T) {
 		}
 	}
 }
+
+// Exercise running environment function
+func TestTelemetryRunningEnvironment(t *testing.T) {
+	telem := &Telemetry{}
+	hypervisor := telem.RunningEnvironment()
+	t.Logf("TestTelemetryRunningEnvironment: hypervisor: %s", hypervisor)
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Include the name of the hypervisor in the telemetry payload when installed in VM.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>