### PR TITLE
gui: Kernel options page

### DIFF
--- a/gui/pages/init.go
+++ b/gui/pages/init.go
@@ -105,6 +105,9 @@ const (
 
 	// PageIDInstall is the special installation page key
 	PageIDInstall = iota
+
+	// PageIDConfigKernel is the advanced option page for kernel selection
+	PageIDConfigKernel = iota
 )
 
 // Private helper to assist in the ugliness of forcibly scrolling a GtkListBox

--- a/gui/pages/kernel_options.go
+++ b/gui/pages/kernel_options.go
@@ -1,0 +1,296 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package pages
+
+import (
+	"github.com/clearlinux/clr-installer/gui/common"
+
+	"github.com/clearlinux/clr-installer/kernel"
+	"github.com/clearlinux/clr-installer/log"
+	"github.com/clearlinux/clr-installer/model"
+	"github.com/clearlinux/clr-installer/utils"
+	"github.com/gotk3/gotk3/gtk"
+	"strings"
+)
+
+// ConfigKernelPage is a page to change kernel installation configuration
+type ConfigKernelPage struct {
+	controller Controller
+	model      *model.SystemInstall
+	box        *gtk.Box
+	addEntry   *gtk.Entry
+	remEntry   *gtk.Entry
+	addLabel   *gtk.Label
+	remLabel   *gtk.Label
+	scroll     *gtk.ScrolledWindow
+	list       *gtk.ListBox
+	data       []*kernel.Kernel
+	selected   *kernel.Kernel
+}
+
+// NewConfigKernelPage returns a new NewConfigKernelPage
+func NewConfigKernelPage(controller Controller, model *model.SystemInstall) (Page, error) {
+	kernelArgsHelp :=
+		utils.Locale.Get("Note: The boot manager tool will first include the \"Add Extra Arguments\" items.")
+	kernelArgsHelp = kernelArgsHelp + "\n" +
+		utils.Locale.Get("Then, the \"Remove Arguments\" items are removed.")
+	kernelArgsHelp = kernelArgsHelp + "\n" +
+		utils.Locale.Get("The final argument list contains the kernel bundle's configured arguments and the ones configured by the user.")
+
+	data, err := kernel.LoadKernelList()
+	if err != nil {
+		return nil, err
+	}
+	page := &ConfigKernelPage{
+		controller: controller,
+		model:      model,
+		data:       data,
+	}
+
+	// Box
+	page.box, err = setBox(gtk.ORIENTATION_VERTICAL, 0, "box-page")
+	if err != nil {
+		return nil, err
+	}
+
+	// ScrolledWindow
+	page.scroll, err = setScrolledWindow(gtk.POLICY_NEVER, gtk.POLICY_AUTOMATIC, "scroller")
+	if err != nil {
+		return nil, err
+	}
+	page.scroll.SetMarginStart(common.StartEndMargin)
+	page.scroll.SetMarginEnd(common.StartEndMargin)
+	page.box.PackStart(page.scroll, true, true, 0)
+
+	// ListBox
+	page.list, err = setListBox(gtk.SELECTION_SINGLE, true, "list-scroller")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := page.list.Connect("row-activated", page.onRowActivated); err != nil {
+		return nil, err
+	}
+	page.scroll.Add(page.list)
+
+	// Create list data
+	for _, v := range page.data {
+		name := v.Name
+		desc := utils.Locale.Get(v.Desc)
+
+		//Add default label to kernel already in model
+		if page.model.Kernel != nil {
+			if v.Bundle == page.model.Kernel.Bundle {
+				name = v.Name + utils.Locale.Get(" (default)")
+			}
+		}
+
+		box, err := setBox(gtk.ORIENTATION_VERTICAL, 0, "box-list-label")
+		if err != nil {
+			return nil, err
+		}
+
+		labelName, err := setLabel(name, "list-label-name", 0.0)
+		if err != nil {
+			return nil, err
+		}
+		box.PackStart(labelName, false, false, 0)
+
+		labelDesc, err := setLabel(desc, "list-label-desc", 0.0)
+		if err != nil {
+			return nil, err
+		}
+		box.PackStart(labelDesc, true, true, 0)
+
+		page.list.Add(box)
+	}
+
+	// addLabel: Tell users they can add kernel command lines below
+	addText := utils.Locale.Get("Add Extra Arguments")
+
+	page.addLabel, err = setLabel(addText, "label-entry", 0.0)
+	if err != nil {
+		return nil, err
+	}
+	page.addLabel.SetMarginStart(common.StartEndMargin)
+	page.addLabel.SetHAlign(gtk.ALIGN_START)
+	page.box.PackStart(page.addLabel, false, false, 10)
+
+	// addEntry: Args to add to the kernel command line
+	page.addEntry, err = setEntry("entry")
+	if err != nil {
+		return nil, err
+	}
+	page.addEntry.SetMarginStart(common.StartEndMargin)
+	page.addEntry.SetMarginEnd(common.StartEndMargin)
+	page.addEntry.SetTooltipText(utils.Locale.Get(kernelArgsHelp))
+	page.box.PackStart(page.addEntry, false, false, 0)
+
+	// remLabel label
+	remText := utils.Locale.Get("Remove Arguments")
+	page.remLabel, err = setLabel(remText, "label-entry", 0.0)
+	if err != nil {
+		return nil, err
+	}
+	page.remLabel.SetMarginStart(common.StartEndMargin)
+	page.remLabel.SetMarginEnd(common.StartEndMargin)
+	page.box.PackStart(page.remLabel, false, false, 10)
+
+	// remEntry: Args to remove to the kernel command line.
+	page.remEntry, err = setEntry("entry")
+	if err != nil {
+		return nil, err
+	}
+	page.remEntry.SetMarginStart(common.StartEndMargin)
+	page.remEntry.SetMarginEnd(common.StartEndMargin)
+	page.remEntry.SetTooltipText(utils.Locale.Get(kernelArgsHelp))
+	page.box.PackStart(page.remEntry, false, false, 0)
+
+	return page, nil
+}
+
+func (page *ConfigKernelPage) getKern() *kernel.Kernel {
+	if page.model.Kernel != nil {
+		return page.model.Kernel
+	}
+
+	// if model is empty, return kernel-native
+	for _, v := range page.data {
+		if v.Bundle == "kernel-native" {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func (page *ConfigKernelPage) onRowActivated(box *gtk.ListBox, row *gtk.ListBoxRow) {
+	page.selected = page.data[row.GetIndex()]
+	page.controller.SetButtonState(ButtonConfirm, true)
+}
+
+// Select row in the box, activate it and scroll to it
+func (page *ConfigKernelPage) activateRow(index int) {
+	row := page.list.GetRowAtIndex(index)
+	page.list.SelectRow(row)
+	page.onRowActivated(page.list, row)
+	scrollToView(page.scroll, page.list, &row.Widget)
+}
+
+// IsRequired will return false as we have default values
+func (page *ConfigKernelPage) IsRequired() bool {
+	return false
+}
+
+// IsDone checks if all the steps are completed
+func (page *ConfigKernelPage) IsDone() bool {
+	//Always true because all steps are optional
+	return true
+}
+
+// GetID returns the ID for this page
+func (page *ConfigKernelPage) GetID() int {
+	return PageIDConfigKernel
+}
+
+// GetIcon returns the icon for this page
+func (page *ConfigKernelPage) GetIcon() string {
+	return "applications-engineering"
+}
+
+// GetRootWidget returns the root embeddable widget for this page
+func (page *ConfigKernelPage) GetRootWidget() gtk.IWidget {
+	return page.box
+}
+
+// GetSummary will return the summary for this page
+func (page *ConfigKernelPage) GetSummary() string {
+	return utils.Locale.Get("Kernel Configuration")
+}
+
+// GetTitle will return the title for this page
+func (page *ConfigKernelPage) GetTitle() string {
+	return page.GetSummary()
+}
+
+// StoreChanges will store this pages changes into the model
+func (page *ConfigKernelPage) StoreChanges() {
+	adds, err := page.addEntry.GetText()
+	if err != nil {
+		log.Warning("Error getting entry text: ", err)
+	}
+
+	removes, err := page.remEntry.GetText()
+	if err != nil {
+		log.Warning("Error getting entry text: ", err)
+	}
+
+	if adds != "" {
+		page.model.AddExtraKernelArguments(strings.Split(adds, " "))
+	} else {
+		page.model.KernelArguments.Add = nil
+	}
+	if removes != "" {
+		page.model.RemoveKernelArguments(strings.Split(removes, " "))
+	} else {
+		page.model.KernelArguments.Remove = nil
+	}
+
+	page.model.Kernel = page.selected
+}
+
+// ResetChanges will reset this page to match the model
+func (page *ConfigKernelPage) ResetChanges() {
+
+	// Reset active row to match the model
+	kern := page.getKern()
+	if kern != nil {
+		for i, v := range page.data {
+			if strings.Contains(v.Bundle, kern.Bundle) {
+				page.activateRow(i)
+				break
+			}
+		}
+	}
+
+	// Reset both entries to match the model
+	if page.model.KernelArguments != nil {
+		page.addEntry.SetText(strings.Join(page.model.KernelArguments.Add, " "))
+		page.remEntry.SetText(strings.Join(page.model.KernelArguments.Remove, " "))
+	} else {
+		page.addEntry.SetText("")
+		page.remEntry.SetText("")
+	}
+}
+
+// GetConfiguredValue returns a string representation of the current config
+func (page *ConfigKernelPage) GetConfiguredValue() string {
+	var ret string
+
+	// Display current kernel/what is in the model
+	if page.model.Kernel != nil {
+		// By default model.Kernel contains only the Bundle information
+		// So, lookup the human-friendly name
+		for _, v := range page.data {
+			if page.model.Kernel.Bundle == v.Bundle {
+				ret = v.Name
+				break
+			}
+		}
+	}
+
+	// The assumption made here is that these arguments were added by the user
+	if page.model.KernelArguments != nil {
+		if len(page.model.KernelArguments.Add) > 0 || len(page.model.KernelArguments.Remove) > 0 {
+			ret = ret + utils.Locale.Get(" with custom command line arguments")
+		}
+	}
+
+	// In case there is no default kernel for whatever reason (eg missing definitions)
+	if ret == "" {
+		return utils.Locale.Get("No custom options specified")
+	}
+
+	return ret
+}

--- a/gui/pages/kernel_options.go
+++ b/gui/pages/kernel_options.go
@@ -17,17 +17,18 @@ import (
 
 // ConfigKernelPage is a page to change kernel installation configuration
 type ConfigKernelPage struct {
-	controller Controller
-	model      *model.SystemInstall
-	box        *gtk.Box
-	addEntry   *gtk.Entry
-	remEntry   *gtk.Entry
-	addLabel   *gtk.Label
-	remLabel   *gtk.Label
-	scroll     *gtk.ScrolledWindow
-	list       *gtk.ListBox
-	data       []*kernel.Kernel
-	selected   *kernel.Kernel
+	controller  Controller
+	model       *model.SystemInstall
+	box         *gtk.Box
+	addEntry    *gtk.Entry
+	remEntry    *gtk.Entry
+	kernelLabel *gtk.Label
+	addLabel    *gtk.Label
+	remLabel    *gtk.Label
+	scroll      *gtk.ScrolledWindow
+	list        *gtk.ListBox
+	data        []*kernel.Kernel
+	selected    *kernel.Kernel
 }
 
 // NewConfigKernelPage returns a new NewConfigKernelPage
@@ -54,6 +55,18 @@ func NewConfigKernelPage(controller Controller, model *model.SystemInstall) (Pag
 	if err != nil {
 		return nil, err
 	}
+
+	// kernelLabel: Tell users they can select a kernel
+	kernelText := utils.Locale.Get("Select Kernel")
+
+	page.kernelLabel, err = setLabel(kernelText, "label-entry", 0.0)
+	if err != nil {
+		return nil, err
+	}
+
+	page.kernelLabel.SetMarginStart(common.StartEndMargin)
+	page.kernelLabel.SetHAlign(gtk.ALIGN_START)
+	page.box.PackStart(page.kernelLabel, false, false, 10)
 
 	// ScrolledWindow
 	page.scroll, err = setScrolledWindow(gtk.POLICY_NEVER, gtk.POLICY_AUTOMATIC, "scroller")
@@ -82,7 +95,7 @@ func NewConfigKernelPage(controller Controller, model *model.SystemInstall) (Pag
 		//Add default label to kernel already in model
 		if page.model.Kernel != nil {
 			if v.Bundle == page.model.Kernel.Bundle {
-				name = v.Name + utils.Locale.Get(" (default)")
+				name = v.Name + " " + utils.Locale.Get("(default)")
 			}
 		}
 
@@ -91,13 +104,13 @@ func NewConfigKernelPage(controller Controller, model *model.SystemInstall) (Pag
 			return nil, err
 		}
 
-		labelName, err := setLabel(name, "list-label-name", 0.0)
+		labelName, err := setLabel(name, "list-label-description", 0.0)
 		if err != nil {
 			return nil, err
 		}
 		box.PackStart(labelName, false, false, 0)
 
-		labelDesc, err := setLabel(desc, "list-label-desc", 0.0)
+		labelDesc, err := setLabel(desc, "list-label-code", 0.0)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +131,7 @@ func NewConfigKernelPage(controller Controller, model *model.SystemInstall) (Pag
 	page.box.PackStart(page.addLabel, false, false, 10)
 
 	// addEntry: Args to add to the kernel command line
-	page.addEntry, err = setEntry("entry")
+	page.addEntry, err = setEntry("entry-no-top-margin")
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +151,7 @@ func NewConfigKernelPage(controller Controller, model *model.SystemInstall) (Pag
 	page.box.PackStart(page.remLabel, false, false, 10)
 
 	// remEntry: Args to remove to the kernel command line.
-	page.remEntry, err = setEntry("entry")
+	page.remEntry, err = setEntry("entry-no-top-margin")
 	if err != nil {
 		return nil, err
 	}

--- a/gui/pages/kernel_options.go
+++ b/gui/pages/kernel_options.go
@@ -229,12 +229,12 @@ func (page *ConfigKernelPage) StoreChanges() {
 	if adds != "" {
 		page.model.AddExtraKernelArguments(strings.Split(adds, " "))
 	} else {
-		page.model.KernelArguments.Add = nil
+		page.model.ClearExtraKernelArguments()
 	}
 	if removes != "" {
 		page.model.RemoveKernelArguments(strings.Split(removes, " "))
 	} else {
-		page.model.KernelArguments.Remove = nil
+		page.model.ClearRemoveKernelArguments()
 	}
 
 	page.model.Kernel = page.selected

--- a/gui/window.go
+++ b/gui/window.go
@@ -262,6 +262,7 @@ func (window *Window) createMenuPages() (*Window, error) {
 		// advanced
 		pages.NewBundlePage,
 		pages.NewHostnamePage,
+		pages.NewConfigKernelPage,
 
 		// always last
 		pages.NewInstallPage,

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -543,8 +543,11 @@ msgstr "Installation in progress."
 msgid "Installation successful."
 msgstr "Installation successful."
 
-msgid " (default)"
-msgstr " (default)"
+msgid "(default)"
+msgstr "(default)"
+
+msgid "Select Kernel"
+msgstr "Select Kernel"
 
 msgid "Add Extra Arguments"
 msgstr "Add Extra Arguments"

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -543,6 +543,45 @@ msgstr "Installation in progress."
 msgid "Installation successful."
 msgstr "Installation successful."
 
+msgid " (default)"
+msgstr " (default)"
+
+msgid "Add Extra Arguments"
+msgstr "Add Extra Arguments"
+
+msgid "Remove Arguments"
+msgstr "Remove Arguments"
+
+msgid "Kernel Configuration"
+msgstr "Kernel Configuration"
+
+msgid " with custom command line arguments"
+msgstr " with custom command line arguments"
+
+msgid "No custom options specified"
+msgstr "No custom options specified"
+
+msgid "Note: The boot manager tool will first include the \"Add Extra Arguments\" items."
+msgstr "Note: The boot manager tool will first include the \"Add Extra Arguments\" items."
+
+msgid "Then, the \"Remove Arguments\" items are removed."
+msgstr "Then, the \"Remove Arguments\" items are removed."
+
+msgid "The final argument list contains the kernel bundle's configured arguments and the ones configured by the user."
+msgstr "The final argument list contains the kernel bundle's configured arguments and the ones configured by the user."
+
+msgid "Bleeding edge bare metal tailored Linux kernel"
+msgstr "Bleeding edge bare metal tailored Linux kernel"
+
+msgid "Run the latest Long Term Support (LTS) Linux Kernel"
+msgstr "Run the latest Long Term Support (LTS) Linux Kernel"
+
+msgid "Run the Long Term Support (LTS) 2018 Linux Kernel 4.19"
+msgstr "Run the Long Term Support (LTS) 2018 Linux Kernel 4.19"
+
+msgid "Run the Long Term Support (LTS) 2017 Linux Kernel 4.14"
+msgstr "Run the Long Term Support (LTS) 2017 Linux Kernel 4.14"
+
 #, c-format
 msgid "See %s for details."
 msgstr "See %s for details."

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -543,8 +543,11 @@ msgstr "Instalación en curso."
 msgid "Installation successful."
 msgstr "Instalación exitosa."
 
-msgid " (default)"
-msgstr " (estándar)"
+msgid "(default)"
+msgstr "(estándar)"
+
+msgid "Select Kernel"
+msgstr "Seleccione Kernel"
 
 msgid "Add Extra Arguments"
 msgstr "Añadir argumentos adicionales"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -543,6 +543,45 @@ msgstr "Instalación en curso."
 msgid "Installation successful."
 msgstr "Instalación exitosa."
 
+msgid " (default)"
+msgstr " (estándar)"
+
+msgid "Add Extra Arguments"
+msgstr "Añadir argumentos adicionales"
+
+msgid "Remove Arguments"
+msgstr "Eliminar argumentos"
+
+msgid "Kernel Configuration"
+msgstr "Configuración del Kernel"
+
+msgid " with custom command line arguments"
+msgstr " con argumentos de línea de comandos personalizados"
+
+msgid "No custom options specified"
+msgstr "No hay opciones personalizadas especificadas"
+
+msgid "Note: The boot manager tool will first include the \"Add Extra Arguments\" items."
+msgstr "Nota: La herramienta de administrador de arranque primero incluirá los elementos \"Agregar argumentos adicionales\"."
+
+msgid "Then, the \"Remove Arguments\" items are removed."
+msgstr "Luego, los elementos \"Eliminar argumentos\" se eliminan."
+
+msgid "The final argument list contains the kernel bundle's configured arguments and the ones configured by the user."
+msgstr "La lista de argumentos final contiene los argumentos configurados del paquete del kernel y los configurados por el usuario."
+
+msgid "Bleeding edge bare metal tailored Linux kernel"
+msgstr "Borde sangrante núcleo Linux a medida de metal"
+
+msgid "Run the latest Long Term Support (LTS) Linux Kernel"
+msgstr "Ejecute el último kernel de Linux de soporte a largo plazo (LTS)"
+
+msgid "Run the Long Term Support (LTS) 2018 Linux Kernel 4.19"
+msgstr "Ejecute el núcleo de soporte a largo plazo (LTS) 2018 Linux Kernel 4.19"
+
+msgid "Run the Long Term Support (LTS) 2017 Linux Kernel 4.14"
+msgstr "Ejecute el núcleo de soporte a largo plazo (LTS) 2017 Linux Kernel 4.14"
+
 #, c-format
 msgid "See %s for details."
 msgstr "Ver %s para más detalles."

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -543,8 +543,11 @@ msgstr "安装正在进行中。"
 msgid "Installation successful."
 msgstr "安装成功。"
 
-msgid " (default)"
-msgstr " (默认)"
+msgid "(default)"
+msgstr "(默认)"
+
+msgid "Select Kernel"
+msgstr "选择内核"
 
 msgid "Add Extra Arguments"
 msgstr "添加额外参数"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -543,6 +543,45 @@ msgstr "安装正在进行中。"
 msgid "Installation successful."
 msgstr "安装成功。"
 
+msgid " (default)"
+msgstr " (默认)"
+
+msgid "Add Extra Arguments"
+msgstr "添加额外参数"
+
+msgid "Remove Arguments"
+msgstr "删除参数"
+
+msgid "Kernel Configuration"
+msgstr "内核配置"
+
+msgid " with custom command line arguments"
+msgstr " 使用自定义命令行参数"
+
+msgid "No custom options specified"
+msgstr "没有指定自定义选项"
+
+msgid "Note: The boot manager tool will first include the \"Add Extra Arguments\" items."
+msgstr "注意：引导管理器工具将首先包含“添加额外参数”项。"
+
+msgid "Then, the \"Remove Arguments\" items are removed."
+msgstr "然后，删除“删除参数”项。"
+
+msgid "The final argument list contains the kernel bundle's configured arguments and the ones configured by the user."
+msgstr "最后的参数列表包含内核包的配置参数和用户配置的参数"
+
+msgid "Bleeding edge bare metal tailored Linux kernel"
+msgstr "出血边缘裸机定制Linux内核"
+
+msgid "Run the latest Long Term Support (LTS) Linux Kernel"
+msgstr "运行最新的长期支持 (LTS) Linux 内核"
+
+msgid "Run the Long Term Support (LTS) 2018 Linux Kernel 4.19"
+msgstr "运行长期支持 (LTS) 2018 Linux 内核 4.19"
+
+msgid "Run the Long Term Support (LTS) 2017 Linux Kernel 4.14"
+msgstr "运行长期支持 (LTS) 2017 Linux 内核 4.14"
+
 #, c-format
 msgid "See %s for details."
 msgstr "请参阅 %s 了解详情。"

--- a/model/model.go
+++ b/model/model.go
@@ -105,6 +105,15 @@ type StorageAlias struct {
 	DeviceFile bool   `yaml:"devicefile,omitempty,flow"`
 }
 
+// ClearExtraKernelArguments clears all of the of custom extra kernel arguments
+func (si *SystemInstall) ClearExtraKernelArguments() {
+	if si.KernelArguments == nil {
+		si.KernelArguments = &kernel.Arguments{}
+	}
+
+	si.KernelArguments.Add = []string{}
+}
+
 // AddExtraKernelArguments adds a set of custom extra kernel arguments to be added to the
 // clr-boot-manager configuration
 func (si *SystemInstall) AddExtraKernelArguments(args []string) {
@@ -119,6 +128,15 @@ func (si *SystemInstall) AddExtraKernelArguments(args []string) {
 
 		si.KernelArguments.Add = append(si.KernelArguments.Add, curr)
 	}
+}
+
+// ClearRemoveKernelArguments clears all of the of custom remove kernel arguments
+func (si *SystemInstall) ClearRemoveKernelArguments() {
+	if si.KernelArguments == nil {
+		si.KernelArguments = &kernel.Arguments{}
+	}
+
+	si.KernelArguments.Remove = []string{}
 }
 
 // RemoveKernelArguments adds a set of kernel arguments to be "black listed" on

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -493,6 +493,36 @@ func TestRemoveKernelArguments(t *testing.T) {
 	}
 }
 
+func TestClearExtraKernelArguments(t *testing.T) {
+	args := []string{"arg1", "arg2", "arg3"}
+
+	si := &SystemInstall{}
+	si.AddExtraKernelArguments(args)
+
+	si.ClearExtraKernelArguments()
+
+	l := len(si.KernelArguments.Add)
+
+	if l > 0 {
+		t.Fatal("Extra Add arguments failed to be cleared")
+	}
+}
+
+func TestClearRemoveKernelArguments(t *testing.T) {
+	args := []string{"arg1", "arg2", "arg3"}
+
+	si := &SystemInstall{}
+	si.RemoveKernelArguments(args)
+
+	si.ClearRemoveKernelArguments()
+
+	l := len(si.KernelArguments.Remove)
+
+	if l > len(si.KernelArguments.Remove) {
+		t.Fatal("Remove arguments failed to be cleared")
+	}
+}
+
 func TestAddEncryptedTargetMedia(t *testing.T) {
 	path := filepath.Join(testsDir, "encrypt-valid-descriptor.yaml")
 	loaded, err := LoadFile(path, args.Args{})

--- a/themes/style.css
+++ b/themes/style.css
@@ -110,6 +110,7 @@ window {
 
 .search-entry,
 .entry,
+.entry-no-top-margin,
 .scroller,
 .list-scroller {
     background-image: none;
@@ -129,7 +130,7 @@ window {
 .list-label-description,
 .list-label-code {
     color: white;
-    padding-left: 20px;
+    padding-left: 10px;
 }
 
 .list-label-description {

--- a/tui/kernel_cmdline.go
+++ b/tui/kernel_cmdline.go
@@ -118,10 +118,14 @@ func newKernelCMDLine(tui *Tui) (Page, error) {
 
 		if addKernelArguments != "" {
 			page.getModel().AddExtraKernelArguments(strings.Split(addKernelArguments, " "))
+		} else {
+			page.getModel().ClearExtraKernelArguments()
 		}
 
 		if remKernelArguments != "" {
 			page.getModel().RemoveKernelArguments(strings.Split(remKernelArguments, " "))
+		} else {
+			page.getModel().ClearRemoveKernelArguments()
 		}
 
 		done := page.addKernelArgEdit.Title() != "" || page.remKernelArgEdit.Title() != ""


### PR DESCRIPTION
Adds a kernel options page to the GUI. Plugs into the back end in a similar manner to the same page on the TUI.
Has a feature for default kernels based on what's loaded in the model already, this means virtualbox installations will by default choose the correct kernel.

Removing more than one flag is problematic, it seems that we just pass the whole value to CBM and it doesn't split strings on space and remove all args.

Fixes Issue: #384, #406

Changes proposed in this pull request:
- Add an advanced menu option to modify kernel-related settings
- Page contains a list of all available kernels, highlights and selects the default, adds text to the default name to indicate default status.
- Localization support is added, but still needs to be properly reviewed and properly vetted.


