### PR TITLE
gui: Fix progress bar to indicate correct status

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -541,7 +541,7 @@ func contentInstall(rootDir string, version string, model *model.SystemInstall, 
 func ConfigureNetwork(model *model.SystemInstall) error {
 	prg, err := configureNetwork(model)
 	if err != nil {
-		prg.Success()
+		prg.Failure()
 		NetworkPassing = false
 		return err
 	}


### PR DESCRIPTION
Currently, the network check is displayed as success even when it fails.
This fixes the bug to indicate the correct progress status.

Signed-off-by: Reagan Lopez <reagan.lopez@intel.com>


