### PR TITLE
gui: Introduces swupd config page

### DIFF
--- a/gui/pages/init.go
+++ b/gui/pages/init.go
@@ -112,6 +112,9 @@ const (
 
 	// PageIDConfigKernel is the advanced option page for kernel selection
 	PageIDConfigKernel = iota
+
+	// PageIDConfigSwupd is the advanced option page to configure swupd
+	PageIDConfigSwupd = iota
 )
 
 // Private helper to assist in the ugliness of forcibly scrolling a GtkListBox

--- a/gui/pages/swupd_config.go
+++ b/gui/pages/swupd_config.go
@@ -67,6 +67,8 @@ func NewSwupdConfigPage(controller Controller, model *model.SystemInstall) (Page
 		return nil, err
 	}
 	page.mirrorDesc.SetMarginStart(common.StartEndMargin)
+	page.mirrorDesc.SetMaxWidthChars(1) // The value does not matter but its required for LineWrap to work
+	page.mirrorDesc.SetLineWrap(true)
 	page.box.PackStart(page.mirrorDesc, false, false, 10)
 
 	page.mirrorEntry, err = setEntry("entry-no-top-margin")
@@ -83,6 +85,8 @@ func NewSwupdConfigPage(controller Controller, model *model.SystemInstall) (Page
 	}
 	page.mirrorWarning.SetMarginStart(common.StartEndMargin)
 	page.mirrorWarning.SetMarginBottom(common.TopBottomMargin)
+	page.mirrorWarning.SetMaxWidthChars(1) // The value does not matter but its required for LineWrap to work
+	page.mirrorWarning.SetLineWrap(true)
 	page.box.PackStart(page.mirrorWarning, false, false, 0)
 	if _, err := page.mirrorEntry.Connect("changed", page.onMirrorChange); err != nil {
 		return nil, err
@@ -111,6 +115,8 @@ func NewSwupdConfigPage(controller Controller, model *model.SystemInstall) (Page
 	}
 	page.autoUpdateDesc.SetMarginStart(common.StartEndMargin)
 	page.autoUpdateDesc.SetMarginTop(common.TopBottomMargin)
+	page.autoUpdateDesc.SetMaxWidthChars(1) // The value does not matter but its required for LineWrap to work
+	page.autoUpdateDesc.SetLineWrap(true)
 	page.autoUpdateDesc.SetSelectable(true)
 	page.box.PackStart(page.autoUpdateDesc, false, false, 0)
 
@@ -139,7 +145,8 @@ func NewSwupdConfigPage(controller Controller, model *model.SystemInstall) (Page
 		return nil, err
 	}
 	page.autoUpdateWarning.SetMarginStart(common.StartEndMargin)
-	page.autoUpdateWarning.SetSelectable(true)
+	page.autoUpdateWarning.SetMaxWidthChars(1) // The value does not matter but its required for LineWrap to work
+	page.autoUpdateWarning.SetLineWrap(true)
 	page.box.PackStart(page.autoUpdateWarning, false, false, 0)
 
 	return page, nil
@@ -277,7 +284,7 @@ func (page *SwupdConfigPage) GetConfiguredValue() string {
 	}
 
 	if page.model.SwupdMirror != "" {
-		ret += utils.Locale.Get(". Custom mirror set.")
+		ret += utils.Locale.Get(".") + " " + utils.Locale.Get("Custom mirror set.")
 	}
 
 	return ret

--- a/gui/pages/swupd_config.go
+++ b/gui/pages/swupd_config.go
@@ -1,0 +1,275 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package pages
+
+import (
+	"net/url"
+
+	"github.com/gotk3/gotk3/gtk"
+
+	"github.com/clearlinux/clr-installer/gui/common"
+	"github.com/clearlinux/clr-installer/log"
+	"github.com/clearlinux/clr-installer/model"
+	"github.com/clearlinux/clr-installer/swupd"
+	"github.com/clearlinux/clr-installer/utils"
+)
+
+// SwupdConfigPage is a page to change swupd configuration
+type SwupdConfigPage struct {
+	controller        Controller
+	model             *model.SystemInstall
+	box               *gtk.Box
+	mirrorHeading     *gtk.Label
+	mirrorDesc        *gtk.Label
+	mirrorEntry       *gtk.Entry
+	mirrorWarning     *gtk.Label
+	autoUpdateHeading *gtk.Label
+	autoUpdateDesc    *gtk.Label
+	autoUpdateButton  *gtk.CheckButton
+	autoUpdateNote    *gtk.Label
+	done              bool
+}
+
+// NewSwupdConfigPage returns a new NewSwupdConfigPage
+func NewSwupdConfigPage(controller Controller, model *model.SystemInstall) (Page, error) {
+	var err error
+
+	page := &SwupdConfigPage{
+		controller: controller,
+		model:      model,
+		done:       true,
+	}
+
+	// Page Box
+	page.box, err = setBox(gtk.ORIENTATION_VERTICAL, 0, "box-page-new")
+	if err != nil {
+		return nil, err
+	}
+
+	// Mirror URL
+	page.mirrorHeading, err = setLabel(utils.Locale.Get("Mirror URL"), "label-entry", 0.0)
+	if err != nil {
+		return nil, err
+	}
+	page.mirrorHeading.SetMarginStart(common.StartEndMargin)
+	page.mirrorHeading.SetMarginTop(common.TopBottomMargin)
+	page.mirrorHeading.SetHAlign(gtk.ALIGN_START)
+	page.box.PackStart(page.mirrorHeading, false, false, 0)
+
+	desc := utils.Locale.Get("Specify a different installation source %s than the default.", "(swupd) URL")
+	desc += " " + utils.Locale.Get("%s sites must use a publicly signed CA.", "HTTPS")
+	page.mirrorDesc, err = setLabel(desc, "", 0)
+	if err != nil {
+		return nil, err
+	}
+	page.mirrorDesc.SetMarginStart(common.StartEndMargin)
+	page.box.PackStart(page.mirrorDesc, false, false, 10)
+
+	page.mirrorEntry, err = setEntry("entry-no-top-margin")
+	if err != nil {
+		return nil, err
+	}
+	page.mirrorEntry.SetMarginStart(common.StartEndMargin)
+	page.mirrorEntry.SetMarginEnd(common.StartEndMargin)
+	page.box.PackStart(page.mirrorEntry, false, false, 0)
+
+	page.mirrorWarning, err = setLabel("", "label-error", 0.0)
+	if err != nil {
+		return nil, err
+	}
+	page.mirrorWarning.SetMarginStart(common.StartEndMargin)
+	page.mirrorWarning.SetMarginBottom(common.TopBottomMargin)
+	page.box.PackStart(page.mirrorWarning, false, false, 0)
+	if _, err := page.mirrorEntry.Connect("changed", page.onMirrorChange); err != nil {
+		return nil, err
+	}
+
+	// Auto Updates
+	page.autoUpdateHeading, err = setLabel(utils.Locale.Get("Automatic OS Updates"), "label-entry", 0.0)
+	if err != nil {
+		return nil, err
+	}
+	page.autoUpdateHeading.SetMarginStart(common.StartEndMargin)
+	page.autoUpdateHeading.SetMarginTop(common.TopBottomMargin)
+	page.autoUpdateHeading.SetHAlign(gtk.ALIGN_START)
+	page.box.PackStart(page.autoUpdateHeading, false, false, 0)
+
+	desc = utils.Locale.Get("Allow the Clear Linux OS to continuously update as new versions are released.")
+	desc += "\n"
+	desc += utils.Locale.Get("This is the default, preferred behavior for Clear Linux OS to ensure that the latest security concerns are always addressed.")
+	desc += "\n"
+	desc += utils.Locale.Get("This can also be enabled post installation using the command %s.", "\"swupd autoupdate --enable\"")
+	desc += "\n"
+	swupdDoc := "https://clearlinux.org/documentation/clear-linux/concepts/swupd-about"
+	desc += utils.Locale.Get("See %s for more information.", swupdDoc)
+	page.autoUpdateDesc, err = setLabel(desc, "", 0)
+	if err != nil {
+		return nil, err
+	}
+	page.autoUpdateDesc.SetMarginStart(common.StartEndMargin)
+	page.autoUpdateDesc.SetMarginTop(common.TopBottomMargin)
+	page.autoUpdateDesc.SetSelectable(true)
+	page.box.PackStart(page.autoUpdateDesc, false, false, 0)
+
+	page.autoUpdateButton, err = gtk.CheckButtonNew()
+	if err != nil {
+		return nil, err
+	}
+	page.autoUpdateButton.SetLabel("  " + utils.Locale.Get("Enable Auto Updates"))
+	page.autoUpdateButton.SetMarginStart(14)         // Custom margin to align properly
+	page.autoUpdateButton.SetHAlign(gtk.ALIGN_START) // Ensures that clickable area is only within the label
+	page.box.PackStart(page.autoUpdateButton, false, false, 10)
+	if _, err := page.autoUpdateButton.Connect("clicked", page.onAutoUpdateClick); err != nil {
+		return nil, err
+	}
+
+	desc = utils.Locale.Get("NOTE:")
+	desc += " "
+	desc += "Disabling Automatic OS Updates puts your system at risk of missing critical security patches."
+	page.autoUpdateNote, err = setLabel(desc, "", 0)
+	if err != nil {
+		return nil, err
+	}
+	page.autoUpdateNote.SetMarginStart(common.StartEndMargin)
+	page.autoUpdateNote.SetSelectable(true)
+	page.box.PackStart(page.autoUpdateNote, false, false, 0)
+
+	return page, nil
+}
+
+func (page *SwupdConfigPage) onMirrorChange(entry *gtk.Entry) {
+	mirror := getTextFromEntry(entry)
+	page.mirrorWarning.SetText("")
+	if mirror != "" {
+		_, err := url.ParseRequestURI(mirror)
+		if err != nil {
+			page.mirrorWarning.SetText(utils.Locale.Get("Invalid URL"))
+		}
+	}
+
+	page.setConfirmButton()
+}
+
+func (page *SwupdConfigPage) validateMirror() {
+	page.controller.SetButtonState(ButtonConfirm, false)
+	mirror := getTextFromEntry(page.mirrorEntry)
+	page.mirrorWarning.SetText("")
+	if mirror == "" {
+		if page.model.SwupdMirror != "" {
+			_, _ = swupd.UnSetHostMirror()
+			page.model.SwupdMirror = mirror // success
+		}
+	} else {
+		url, err := swupd.SetHostMirror(mirror)
+		if err != nil {
+			page.mirrorWarning.SetText(err.Error()) // failure
+		} else {
+			if url != mirror { // At this point, url and mirror are expected to be the same
+				page.mirrorWarning.SetText(utils.Locale.Get("Mirror not set correctly")) // failure
+			} else {
+				page.model.SwupdMirror = mirror // success
+			}
+		}
+	}
+
+	page.setConfirmButton()
+}
+
+func (page *SwupdConfigPage) onAutoUpdateClick(button *gtk.CheckButton) {
+	var removeStyle, addStyle string
+	if button.GetActive() {
+		removeStyle = "label-error"
+		addStyle = ""
+	} else {
+		removeStyle = ""
+		addStyle = "label-error"
+	}
+
+	sc, err := page.autoUpdateNote.GetStyleContext()
+	if err != nil {
+		log.Warning("Error getting style context: ", err) // Just log trivial error
+	} else {
+		sc.RemoveClass(removeStyle)
+		sc.AddClass(addStyle)
+	}
+}
+
+func (page *SwupdConfigPage) setConfirmButton() {
+	warning, err := page.mirrorWarning.GetText()
+	if err != nil {
+		log.ErrorError(err) // Just log trivial errors
+	}
+	if warning == "" {
+		page.done = true
+		page.controller.SetButtonState(ButtonConfirm, true)
+	} else {
+		page.done = false
+		page.controller.SetButtonState(ButtonConfirm, false)
+	}
+}
+
+// IsRequired will return false as we have default values
+func (page *SwupdConfigPage) IsRequired() bool {
+	return false
+}
+
+// IsDone checks if all the steps are completed
+func (page *SwupdConfigPage) IsDone() bool {
+	return page.done
+}
+
+// GetID returns the ID for this page
+func (page *SwupdConfigPage) GetID() int {
+	return PageIDConfigSwupd
+}
+
+// GetIcon returns the icon for this page
+func (page *SwupdConfigPage) GetIcon() string {
+	return "software-update-available-symbolic"
+}
+
+// GetRootWidget returns the root embeddable widget for this page
+func (page *SwupdConfigPage) GetRootWidget() gtk.IWidget {
+	return page.box
+}
+
+// GetSummary will return the summary for this page
+func (page *SwupdConfigPage) GetSummary() string {
+	return utils.Locale.Get("Software Updater Configuration")
+}
+
+// GetTitle will return the title for this page
+func (page *SwupdConfigPage) GetTitle() string {
+	return page.GetSummary()
+}
+
+// StoreChanges will store this pages changes into the model
+func (page *SwupdConfigPage) StoreChanges() {
+	page.validateMirror()
+	page.model.AutoUpdate = page.autoUpdateButton.GetActive()
+}
+
+// ResetChanges will reset this page to match the model
+func (page *SwupdConfigPage) ResetChanges() {
+	page.controller.SetButtonState(ButtonConfirm, true)
+	setTextInEntry(page.mirrorEntry, page.model.SwupdMirror)
+	page.autoUpdateButton.SetActive(page.model.AutoUpdate)
+}
+
+// GetConfiguredValue returns a string representation of the current config
+func (page *SwupdConfigPage) GetConfiguredValue() string {
+	var ret string
+	if page.model.AutoUpdate {
+		ret = utils.Locale.Get("Auto updates enabled")
+	} else {
+		ret = utils.Locale.Get("Auto updates disabled")
+	}
+
+	if page.model.SwupdMirror != "" {
+		ret += utils.Locale.Get(". Custom mirror set.")
+	}
+
+	return ret
+}

--- a/gui/pages/telemetry.go
+++ b/gui/pages/telemetry.go
@@ -17,7 +17,7 @@ type Telemetry struct {
 	model      *model.SystemInstall
 	controller Controller
 	box        *gtk.Box
-	didConfirm bool
+	done       bool
 	firstLoad  bool // Keeps track if the page was loaded for the first time.
 }
 
@@ -46,7 +46,7 @@ func NewTelemetryPage(controller Controller, model *model.SystemInstall) (Page, 
 		controller: controller,
 		model:      model,
 		box:        box,
-		didConfirm: false,
+		done:       false,
 		firstLoad:  true,
 	}, nil
 }
@@ -58,7 +58,7 @@ func (page *Telemetry) IsRequired() bool {
 
 // IsDone checks if all the steps are completed
 func (page *Telemetry) IsDone() bool {
-	return page.didConfirm
+	return page.done
 }
 
 // GetID returns the ID for this page
@@ -88,24 +88,24 @@ func (page *Telemetry) GetTitle() string {
 
 // StoreChanges will store this pages changes into the model
 func (page *Telemetry) StoreChanges() {
-	page.didConfirm = true
+	page.done = true
 	page.model.EnableTelemetry(true)
 }
 
 // ResetChanges will reset this page to match the model
 func (page *Telemetry) ResetChanges() {
 	if page.firstLoad {
-		page.didConfirm = false
+		page.done = false
 		page.firstLoad = false
 	} else {
-		page.didConfirm = true
+		page.done = true
 	}
 	page.model.EnableTelemetry(false)
 }
 
 // GetConfiguredValue returns our current config
 func (page *Telemetry) GetConfiguredValue() string {
-	if page.didConfirm {
+	if page.done {
 		if page.model.IsTelemetryEnabled() {
 			return utils.Locale.Get("Enabled")
 		}

--- a/gui/pages/user_add.go
+++ b/gui/pages/user_add.go
@@ -438,6 +438,8 @@ func (page *UserAddPage) setSimilarWidgets(entryText, rulesText string, maxSize 
 		return nil, nil, err
 	}
 	rulesLabel.SetMarginStart(CommonSetting + common.StartEndMargin)
+	rulesLabel.SetMaxWidthChars(1) // The value does not matter but its required for LineWrap to work
+	rulesLabel.SetLineWrap(true)
 	page.box.PackStart(rulesLabel, false, false, 0)
 
 	// Warning
@@ -446,6 +448,8 @@ func (page *UserAddPage) setSimilarWidgets(entryText, rulesText string, maxSize 
 		return nil, nil, err
 	}
 	warningLabel.SetMarginStart(CommonSetting + common.StartEndMargin)
+	warningLabel.SetMaxWidthChars(1) // The value does not matter but its required for LineWrap to work
+	warningLabel.SetLineWrap(true)
 	page.box.PackStart(warningLabel, false, false, 0)
 
 	return entry, warningLabel, err
@@ -467,6 +471,8 @@ func (page *UserAddPage) setPasswordWidgets(rulesText string, maxSize int) (*gtk
 		return nil, nil, nil, err
 	}
 	rulesLabel.SetMarginStart(CommonSetting + common.StartEndMargin)
+	rulesLabel.SetMaxWidthChars(1) // The value does not matter but its required for LineWrap to work
+	rulesLabel.SetLineWrap(true)
 	page.box.PackStart(rulesLabel, false, false, 0)
 
 	boxPasswordConfirm, passwordConfirm, err := setLabelAndEntry(utils.Locale.Get("Confirm")+" *", maxSize)
@@ -484,6 +490,8 @@ func (page *UserAddPage) setPasswordWidgets(rulesText string, maxSize int) (*gtk
 		return nil, nil, nil, err
 	}
 	warningLabel.SetMarginStart(CommonSetting + common.StartEndMargin)
+	warningLabel.SetMaxWidthChars(1) // The value does not matter but its required for LineWrap to work
+	warningLabel.SetLineWrap(true)
 	page.box.PackStart(warningLabel, false, false, 0)
 
 	return password, passwordConfirm, warningLabel, err

--- a/gui/window.go
+++ b/gui/window.go
@@ -294,6 +294,7 @@ func (window *Window) createMenuPages() (*Window, error) {
 		pages.NewBundlePage,
 		pages.NewHostnamePage,
 		pages.NewConfigKernelPage,
+		pages.NewSwupdConfigPage,
 
 		// always last
 		pages.NewInstallPage,
@@ -545,19 +546,22 @@ func (window *Window) pageClosed(applied bool) {
 
 	// Let installation continue if possible
 	done := window.menu.screens[ContentViewRequired].IsDone()
-	window.buttons.install.SetSensitive(done)
 
-	// Reset the SummaryWidget for responsible controller
-	window.menu.screens[window.menu.currentPage.IsRequired()].UpdateView(window.menu.currentPage)
+	if window.menu.currentPage.IsDone() {
+		window.buttons.install.SetSensitive(done)
 
-	// Reset currentPage
-	window.menu.currentPage = nil
+		// Reset the SummaryWidget for responsible controller
+		window.menu.screens[window.menu.currentPage.IsRequired()].UpdateView(window.menu.currentPage)
 
-	// Switch UI back to primary view
-	window.rootStack.SetVisibleChildName("menu")
-	window.banner.Show()
-	window.menu.switcher.Show()
-	window.buttons.stack.SetVisibleChildName("primary")
+		// Reset currentPage
+		window.menu.currentPage = nil
+
+		// Switch UI back to primary view
+		window.rootStack.SetVisibleChildName("menu")
+		window.banner.Show()
+		window.menu.switcher.Show()
+		window.buttons.stack.SetVisibleChildName("primary")
+	}
 }
 
 // ActivatePage customizes common widgets and displays the page

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -623,3 +623,61 @@ msgstr "You may need to remove any personal data of concern from the attachments
 
 msgid "The Installer will now exit."
 msgstr "The Installer will now exit."
+
+msgid "Mirror URL"
+msgstr "Mirror URL"
+
+msgid "Specify a different installation source (swupd) URL than the default."
+msgstr "Specify a different installation source (swupd) URL than the default."
+
+msgid "HTTPS sites must use a publicly signed CA."
+msgstr "HTTPS sites must use a publicly signed CA."
+
+msgid "Automatic OS Updates"
+msgstr "Automatic OS Updates"
+
+msgid "Allow Clear Linux* OS to continuously update as new versions are released."
+msgstr "Allow Clear Linux* OS to continuously update as new versions are released."
+
+msgid "This is the default, preferred behavior for Clear Linux* OS to ensure that the latest security concerns are always addressed."
+msgstr "This is the default, preferred behavior for Clear Linux* OS to ensure that the latest security concerns are always addressed."
+
+msgid "To enable this post installation use:"
+msgstr "To enable this post installation use:"
+
+#, c-format
+msgid "See %s for more information."
+msgstr "See %s for more information."
+
+msgid "Enable Auto Updates"
+msgstr "Enable Auto Updates"
+
+msgid "WARNING: Disabling Automatic OS Updates puts the system at risk of missing critical security patches."
+msgstr "WARNING: Disabling Automatic OS Updates puts the system at risk of missing critical security patches."
+
+msgid "Invalid URL"
+msgstr "Invalid URL"
+
+msgid "Mirror not set correctly"
+msgstr "Mirror not set correctly"
+
+msgid "Software Updater Configuration"
+msgstr "Software Updater Configuration"
+
+msgid "Auto updates enabled"
+msgstr "Auto updates enabled"
+
+msgid "Auto updates disabled"
+msgstr "Auto updates disabled"
+
+msgid ". Custom mirror set."
+msgstr ". Custom mirror set."
+
+msgid "Server not responding"
+msgstr "Server not responding"
+
+msgid "Server does not report any version"
+msgstr "Server does not report any version"
+
+msgid "Version URL of mirror not found"
+msgstr "Version URL of mirror not found"

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -670,8 +670,8 @@ msgstr "Auto updates enabled"
 msgid "Auto updates disabled"
 msgstr "Auto updates disabled"
 
-msgid ". Custom mirror set."
-msgstr ". Custom mirror set."
+msgid "Custom mirror set."
+msgstr "Custom mirror set."
 
 msgid "Server not responding"
 msgstr "Server not responding"
@@ -681,3 +681,6 @@ msgstr "Server does not report any version"
 
 msgid "Version URL of mirror not found"
 msgstr "Version URL of mirror not found"
+
+msgid "."
+msgstr "."

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -623,3 +623,61 @@ msgstr "Es posible que deba eliminar cualquier dato personal de preocupación de
 
 msgid "The Installer will now exit."
 msgstr "El instalador se cerrará ahora."
+
+msgid "Mirror URL"
+msgstr "URL de espejo"
+
+msgid "Specify a different installation source (swupd) URL than the default."
+msgstr "Especifique un origen de instalación (swupd) URL diferente al predeterminado."
+
+msgid "HTTPS sites must use a publicly signed CA."
+msgstr "Los sitios HTTPS deben usar una CA firmada públicamente."
+
+msgid "Automatic OS Updates"
+msgstr "Actualizaciones automáticas del sistema operativo"
+
+msgid "Allow Clear Linux* OS to continuously update as new versions are released."
+msgstr "Permita que Clear Linux* OS se actualice continuamente a medida que se lanzan nuevas versiones."
+
+msgid "This is the default, preferred behavior for Clear Linux* OS to ensure that the latest security concerns are always addressed."
+msgstr "Este es el comportamiento predeterminado y preferido para Clear Linux* OS para asegurarse de que siempre se abordan los problemas de seguridad más recientes."
+
+msgid "To enable this post installation use:"
+msgstr "Para habilitar este uso posterior a la instalación:"
+
+#, c-format
+msgid "See %s for more information."
+msgstr "Consulte %s para obtener más información."
+
+msgid "Enable Auto Updates"
+msgstr "Habilitar actualizaciones automáticas"
+
+msgid "WARNING: Disabling Automatic OS Updates puts the system at risk of missing critical security patches."
+msgstr "ADVERTENCIA: La desactivación de las actualizaciones automáticas del sistema operativo pone al sistema en riesgo de perder parches de seguridad críticos."
+
+msgid "Invalid URL"
+msgstr "URL no válida"
+
+msgid "Mirror not set correctly"
+msgstr "Espejo no configurado correctamente"
+
+msgid "Software Updater Configuration"
+msgstr "Configuración del actualizador de software"
+
+msgid "Auto updates enabled"
+msgstr "Actualizaciones automáticas habilitadas"
+
+msgid "Auto updates disabled"
+msgstr "Actualizaciones automáticas desactivadas"
+
+msgid ". Custom mirror set."
+msgstr ". Conjunto de espejos personalizado."
+
+msgid "Server not responding"
+msgstr "Servidor que no responde"
+
+msgid "Server does not report any version"
+msgstr "El servidor no informa de ninguna versión"
+
+msgid "Version URL of mirror not found"
+msgstr "Versión URL del espejo no encontrada"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -670,8 +670,8 @@ msgstr "Actualizaciones automáticas habilitadas"
 msgid "Auto updates disabled"
 msgstr "Actualizaciones automáticas desactivadas"
 
-msgid ". Custom mirror set."
-msgstr ". Conjunto de espejos personalizado."
+msgid "Custom mirror set."
+msgstr "Conjunto de espejos personalizado."
 
 msgid "Server not responding"
 msgstr "Servidor que no responde"
@@ -681,3 +681,6 @@ msgstr "El servidor no informa de ninguna versión"
 
 msgid "Version URL of mirror not found"
 msgstr "Versión URL del espejo no encontrada"
+
+msgid "."
+msgstr "."

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -670,8 +670,8 @@ msgstr "启用自动更新"
 msgid "Auto updates disabled"
 msgstr "已禁用自动更新"
 
-msgid ". Custom mirror set."
-msgstr ".自定义镜像集。"
+msgid "Custom mirror set."
+msgstr "自定义镜像集。"
 
 msgid "Server not responding"
 msgstr "服务器未响应"
@@ -681,3 +681,6 @@ msgstr "服务器不报告任何版本"
 
 msgid "Version URL of mirror not found"
 msgstr "未找到镜像的版本 URL"
+
+msgid "."
+msgstr "。"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -623,3 +623,61 @@ msgstr "您可能需要从附件中删除任何值得关注的个人数据。"
 
 msgid "The Installer will now exit."
 msgstr "安装程序现在将退出。"
+
+msgid "Mirror URL"
+msgstr "镜子 URL"
+
+msgid "Specify a different installation source (swupd) URL than the default."
+msgstr "指定与默认安装源(swupd) URL 不同的 URL。"
+
+msgid "HTTPS sites must use a publicly signed CA."
+msgstr "HTTPS 站点必须使用公开签名的 CA。"
+
+msgid "Automatic OS Updates"
+msgstr "自动操作系统更新"
+
+msgid "Allow Clear Linux* OS to continuously update as new versions are released."
+msgstr "允许 Clear Linux* OS 在发布新版本时持续更新。"
+
+msgid "This is the default, preferred behavior for Clear Linux* OS to ensure that the latest security concerns are always addressed."
+msgstr "这是 Clear Linux* OS 的默认首选行为,可确保始终解决最新的安全问题。"
+
+msgid "To enable this post installation use:"
+msgstr "要启用此安装后使用:"
+
+#, c-format
+msgid "See %s for more information."
+msgstr "有关详细信息,请参阅 %s。"
+
+msgid "Enable Auto Updates"
+msgstr "启用自动更新"
+
+msgid "WARNING: Disabling Automatic OS Updates puts the system at risk of missing critical security patches."
+msgstr "警告: 禁用自动操作系统更新会使系统面临丢失关键安全修补程序的风险。"
+
+msgid "Invalid URL"
+msgstr "无效 URL"
+
+msgid "Mirror not set correctly"
+msgstr "镜像设置不正确"
+
+msgid "Software Updater Configuration"
+msgstr "软件更新器配置"
+
+msgid "Auto updates enabled"
+msgstr "启用自动更新"
+
+msgid "Auto updates disabled"
+msgstr "已禁用自动更新"
+
+msgid ". Custom mirror set."
+msgstr ".自定义镜像集。"
+
+msgid "Server not responding"
+msgstr "服务器未响应"
+
+msgid "Server does not report any version"
+msgstr "服务器不报告任何版本"
+
+msgid "Version URL of mirror not found"
+msgstr "未找到镜像的版本 URL"

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -412,7 +412,7 @@ func setMirror(swupdArgs []string, t string) (string, error) {
 func SetHostMirror(url string) (string, error) {
 
 	if urlErr := network.CheckURL(url); urlErr != nil {
-		return "", fmt.Errorf("Server not responding")
+		return "", fmt.Errorf(utils.Locale.Get("Server not responding"))
 	}
 
 	args := []string{
@@ -487,7 +487,7 @@ func checkSwupd(swupdArgs []string, t string) error {
 		// Swupd uses exit status '1' when there are no updates (and no errors)
 		if !strings.Contains(w.String(), "There are no updates available") {
 			log.Debug("%s swupd check-update failed: %q", t, fmt.Errorf("%s", w.String()))
-			err = fmt.Errorf("Server does not report any version")
+			err = fmt.Errorf(utils.Locale.Get("Server does not report any version"))
 		} else {
 			log.Debug("%s swupd check-update results ignored: %q", t, err)
 			err = nil
@@ -517,7 +517,7 @@ func parseSwupdMirror(data []byte) (string, error) {
 	match := versionExp.FindSubmatch(data)
 
 	if len(match) != 2 {
-		return "", errors.Errorf("swupd mirror Version URL not found")
+		return "", errors.Errorf(utils.Locale.Get("swupd mirror Version %s not found", "URL"))
 	}
 
 	return string(match[1]), nil

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -25,6 +25,53 @@ import (
 	"github.com/clearlinux/clr-installer/utils"
 )
 
+const (
+	// MirrorTitle specifies title of swupd mirror
+	MirrorTitle = "Mirror URL"
+
+	// MirrorDesc1 specifies line 1 of swupd mirror desc
+	MirrorDesc1 = "Specify a different installation source (swupd) URL than the default."
+
+	// MirrorDesc2 specifies line 2 of swupd mirror desc
+	MirrorDesc2 = "HTTPS sites must use a publicly signed CA."
+
+	// AutoUpdateTitle specifies title of auto updates
+	AutoUpdateTitle = "Automatic OS Updates"
+
+	// AutoUpdateDesc1 specifies line 1 of auto updates desc
+	AutoUpdateDesc1 = "Allow Clear Linux OS to continuously update as new versions are released."
+
+	// AutoUpdateDesc2 specifies line 2 of auto updates desc
+	AutoUpdateDesc2 = "This is the default, preferred behavior for Clear Linux OS to ensure that the latest security concerns are always addressed."
+
+	// AutoUpdateDesc3 specifies line 3 of auto updates desc
+	AutoUpdateDesc3 = "To enable this post installation use:"
+
+	// AutoUpdateDesc4 specifies line 4 of auto updates desc
+	AutoUpdateDesc4 = "See %s for more information."
+
+	// AutoUpdateCommand specifies auto updates enable command
+	AutoUpdateCommand = "\"swupd autoupdate --enable\""
+
+	// AutoUpdateLink specifies document link of auto updates
+	AutoUpdateLink = "https://clearlinux.org/documentation/clear-linux/concepts/swupd-about"
+
+	// AutoUpdateLabel specifies label of auto updates
+	AutoUpdateLabel = "Enable Auto Updates"
+
+	// AutoUpdateWarning1 specifies part 1 of auto updates warning
+	AutoUpdateWarning1 = "WARNING: Disabling Automatic OS Updates puts the system at risk of "
+
+	// AutoUpdateWarning2 specifies part 2 of auto updates desc
+	AutoUpdateWarning2 = "missing critical security patches."
+
+	// InvalidURL specifies invalid url error message
+	InvalidURL = "Invalid URL"
+
+	// IncorrectMirror specifies incorrect mirror error message
+	IncorrectMirror = "Mirror not set correctly"
+)
+
 var (
 	// CoreBundles represents the core bundles installed in the Verify() operation
 	CoreBundles = []string{

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -39,10 +39,10 @@ const (
 	AutoUpdateTitle = "Automatic OS Updates"
 
 	// AutoUpdateDesc1 specifies line 1 of auto updates desc
-	AutoUpdateDesc1 = "Allow Clear Linux OS to continuously update as new versions are released."
+	AutoUpdateDesc1 = "Allow Clear Linux* OS to continuously update as new versions are released."
 
 	// AutoUpdateDesc2 specifies line 2 of auto updates desc
-	AutoUpdateDesc2 = "This is the default, preferred behavior for Clear Linux OS to ensure that the latest security concerns are always addressed."
+	AutoUpdateDesc2 = "This is the default, preferred behavior for Clear Linux* OS to ensure that the latest security concerns are always addressed."
 
 	// AutoUpdateDesc3 specifies line 3 of auto updates desc
 	AutoUpdateDesc3 = "To enable this post installation use:"
@@ -564,7 +564,7 @@ func parseSwupdMirror(data []byte) (string, error) {
 	match := versionExp.FindSubmatch(data)
 
 	if len(match) != 2 {
-		return "", errors.Errorf(utils.Locale.Get("swupd mirror Version %s not found", "URL"))
+		return "", errors.Errorf(utils.Locale.Get("Version URL of mirror not found"))
 	}
 
 	return string(match[1]), nil

--- a/tui/autoupdate.go
+++ b/tui/autoupdate.go
@@ -6,32 +6,13 @@ package tui
 
 import (
 	"github.com/VladimirMarkelov/clui"
+	"github.com/clearlinux/clr-installer/swupd"
 )
 
 // AutoUpdatePage is the Page implementation for the auto update enable configuration page
 type AutoUpdatePage struct {
 	BasePage
 }
-
-const (
-	autoUpdateHelp = `
-Automatic OS Updates
-
-Allow the Clear Linux OS to continuously update as new versions are
-released. This is the default, preferred behavior for Clear Linux OS
-to ensure the latest security concerns are always addressed.
-
-See
-https://clearlinux.org/documentation/clear-linux/concepts/swupd-about
-for more information.
-
-WARNING: Disabling Automatic OS Updates puts your system at risk of
-missing critical security patches.
-To enable post-installation, use:
-    # swupd autoupdate --enable
-
-`
-)
 
 // GetConfiguredValue Returns the string representation of currently value set
 func (aup *AutoUpdatePage) GetConfiguredValue() string {
@@ -44,10 +25,22 @@ func (aup *AutoUpdatePage) GetConfiguredValue() string {
 func newAutoUpdatePage(tui *Tui) (Page, error) {
 	page := &AutoUpdatePage{}
 
-	page.setupMenu(tui, TuiPageAutoUpdate, "Automatic OS Updates",
+	page.setupMenu(tui, TuiPageAutoUpdate, swupd.AutoUpdateTitle,
 		BackButton|ConfirmButton, TuiPageMenu)
 
-	lbl := clui.CreateLabel(page.content, 2, 16, autoUpdateHelp, Fixed)
+	desc := swupd.AutoUpdateTitle
+	desc += "\n\n"
+	desc += swupd.AutoUpdateDesc1
+	desc += "\n"
+	desc += swupd.AutoUpdateDesc2
+	desc += "\n\n"
+	desc += swupd.AutoUpdateDesc3 + " " + swupd.AutoUpdateCommand
+	desc += "\n\n"
+	desc += "See" + "\n" + swupd.AutoUpdateLink + "\n" + "for more information."
+	desc += "\n\n"
+	desc += swupd.AutoUpdateWarning1 + "\n" + swupd.AutoUpdateWarning2
+
+	lbl := clui.CreateLabel(page.content, 2, 16, desc, Fixed)
 	lbl.SetMultiline(true)
 
 	page.backBtn.SetTitle("No [Disable]")

--- a/tui/swupd_mirror.go
+++ b/tui/swupd_mirror.go
@@ -64,8 +64,7 @@ func (page *SwupdMirrorPage) setConfirmButton() {
 func newSwupdMirrorPage(tui *Tui) (Page, error) {
 	page := &SwupdMirrorPage{}
 	page.setupMenu(tui, TuiPageSwupdMirror, "Swupd Mirror", NoButtons, TuiPageMenu)
-
-	clui.CreateLabel(page.content, 2, 2, "Configure the Installation Source (swupd) Mirror", Fixed)
+	clui.CreateLabel(page.content, 2, 2, swupd.MirrorDesc1, Fixed)
 
 	frm := clui.CreateFrame(page.content, AutoSize, AutoSize, BorderNone, Fixed)
 	frm.SetPack(clui.Horizontal)
@@ -73,8 +72,8 @@ func newSwupdMirrorPage(tui *Tui) (Page, error) {
 	lblFrm := clui.CreateFrame(frm, 20, AutoSize, BorderNone, Fixed)
 	lblFrm.SetPack(clui.Vertical)
 	lblFrm.SetPaddings(1, 0)
-
-	newFieldLabel(lblFrm, "Mirror URL:")
+	title := swupd.MirrorTitle + ":"
+	newFieldLabel(lblFrm, title)
 
 	fldFrm := clui.CreateFrame(frm, 30, AutoSize, BorderNone, Fixed)
 	fldFrm.SetPack(clui.Vertical)
@@ -90,7 +89,7 @@ func newSwupdMirrorPage(tui *Tui) (Page, error) {
 		if userURL != "" {
 			_, err := url.ParseRequestURI(page.swupdMirrorEdit.Title())
 			if err != nil {
-				warning = "Invalid URL"
+				warning = swupd.InvalidURL
 			}
 		}
 
@@ -102,7 +101,7 @@ func newSwupdMirrorPage(tui *Tui) (Page, error) {
 	page.swupdMirrorWarning.SetMultiline(true)
 	page.swupdMirrorWarning.SetBackColor(errorLabelBg)
 	page.swupdMirrorWarning.SetTextColor(errorLabelFg)
-	lbl := clui.CreateLabel(iframe, 2, 11, "HTTPS sites must use a publicly signed CA", Fixed)
+	lbl := clui.CreateLabel(iframe, 2, 11, swupd.MirrorDesc2, Fixed)
 	lbl.SetMultiline(true)
 
 	btnFrm := clui.CreateFrame(fldFrm, 50, 1, BorderNone, Fixed)
@@ -133,7 +132,7 @@ func newSwupdMirrorPage(tui *Tui) (Page, error) {
 				page.swupdMirrorWarning.SetTitle(err.Error())
 			} else {
 				if url != mirror {
-					page.swupdMirrorWarning.SetTitle("Mirror not set correctly: " + url)
+					page.swupdMirrorWarning.SetTitle(swupd.IncorrectMirror + ": " + url)
 				} else {
 					page.userDefined = true
 					page.getModel().SwupdMirror = mirror

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -107,12 +107,12 @@ func (tui *Tui) Run(md *model.SystemInstall, rootDir string, options args.Args) 
 		{"bundle selection", newBundlePage},
 		{"add manager", newUserManagerPage},
 		{"add user", newUseraddPage},
+		{"hostname", newHostnamePage},
 		{"telemetry enabling", newTelemetryPage},
 		{"kernel cmdline", newKernelCMDLine},
 		{"kernel selection", newKernelPage},
 		{"install", newInstallPage},
 		{"swupd mirror", newSwupdMirrorPage},
-		{"hostname", newHostnamePage},
 		{"autoupdate", newAutoUpdatePage},
 		{"save config", newSaveConfigPage},
 	}


### PR DESCRIPTION
**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #405 #407 #455

Changes proposed in this pull request:
- Introduces swupd config page that can be used to set Mirror URL and Auto Updates
- Moved associated common GUI and TUI strings to swupd.go
- Added corresponding translations
- Made the change to display swupd related pages in sequence in the TUI menu.
- Fixed resize issue due to long strings in **User Add** page #455 as part of fixing the same for this page.
- Refactored code to handle closing pages due to a bug introduced in this PR.


