### PR TITLE
Reduce bundles in hyperv.yml

### DIFF
--- a/scripts/hyperv.yaml
+++ b/scripts/hyperv.yaml
@@ -28,12 +28,9 @@ targetMedia:
 
 bundles: [
     bootloader,
-    editors,
-    network-basic,
     openssh-server,
     os-core,
     os-core-update,
-    sysadmin-basic,
   ]
 
 autoUpdate: false


### PR DESCRIPTION
Fixes Issue: https://github.com/clearlinux/distribution/issues/622

Changes proposed in this pull request:
- Remove  editors, network-basic, and sysadmin-basic bundle from Hyper-V image.


> This should be user-installed, not pre-installed in my opinion. Especially without a good way to recursively remove bundles.