### PR TITLE
Telemetry

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -89,20 +89,6 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		if err = applyHooks("pre-install", vars, model.PreInstall); err != nil {
 			return err
 		}
-
-		if model.Telemetry.Enabled {
-			if err = model.Telemetry.CreateLocalTelemetryConf(); err != nil {
-				return err
-			}
-			if model.Telemetry.URL != "" {
-				if err = model.Telemetry.UpdateLocalTelemetryServer(); err != nil {
-					return err
-				}
-			}
-			if err = model.Telemetry.RestartLocalTelemetryServer(); err != nil {
-				return err
-			}
-		}
 	}
 
 	if model.Version == 0 {
@@ -748,14 +734,6 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 	}
 
 	if md.IsTelemetryEnabled() {
-		// Give Telemetry a chance to send before we shutdown and copy
-		time.Sleep(2 * time.Second)
-
-		if err := md.Telemetry.StopLocalTelemetryServer(); err != nil {
-			log.Warning("Failed to stop image Telemetry server")
-			errMsgs = append(errMsgs, "Failed to stop image Telemetry server")
-		}
-
 		log.Info("Copying telemetry records to target system.")
 		if err := md.Telemetry.CopyTelemetryRecords(rootDir); err != nil {
 			log.Warning("Failed to copy image Telemetry data")

--- a/scripts/local-telemetry-post.sh
+++ b/scripts/local-telemetry-post.sh
@@ -4,12 +4,13 @@
 echo "Creating custom telemetry configuration for $1"
 mkdir -p $1/etc/telemetrics/
 
-cp $1/usr/share/defaults/telemetrics/telemetrics.conf \
-   $1/etc/telemetrics/telemetrics.conf
-
-sed -i -e '/server=/s/clr.telemetry.intel.com/localhost/' \
-    -e '/spool_process_time/s/=120/=300/' \
-    -e '/record_retention_enabled/s/=false/=true/' \
-    $1/etc/telemetrics/telemetrics.conf
+# Create configuration to keep data private
+if [[ ! -f "$1/etc/telemetrics/telemetrics.conf" ]];then
+        cat <<EOF > $1/etc/telemetrics/telemetrics.conf
+server=http://localhost/v2/collector
+record_server_delivery_enabled=false
+record_retention_enabled=true
+EOF
+fi
 
 exit 0

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -5,6 +5,7 @@
 package telemetry
 
 import (
+	"bytes"
 	"crypto/md5"
 	"crypto/rand"
 	"fmt"
@@ -14,7 +15,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -31,9 +31,8 @@ const (
 	RequiredBundle = "telemetrics"
 
 	// Default Telemetry configuration file
-	defaultTelemetryConf = "/usr/share/defaults/telemetrics/telemetrics.conf"
-	customTelemetryConf  = "/etc/telemetrics/telemetrics.conf"
-	telemetrySpoolDir    = "/var/spool/telemetry"
+	customTelemetryConf = "/etc/telemetrics/telemetrics.conf"
+	telemetrySpoolDir   = "/var/spool/telemetry"
 
 	// Title is a predefined text to display on the Telemetry
 	Title = `Enable Telemetry`
@@ -60,6 +59,12 @@ is collected.
 
 	// Detect hypervisor if running in VM
 	envCmd = "/usr/bin/systemd-detect-virt"
+
+	// Configuration template
+	configTemplate = `[settings]
+server=%s
+tidheader=X-Telemetry-TID:\s%s
+`
 )
 
 var (
@@ -71,9 +76,6 @@ var (
 	// ProgVersion is the version of this Clear Installer set from the Model
 	// since telemetry is a component of the model, can directly include the model here
 	ProgVersion string
-
-	serverExp = regexp.MustCompile(`(?im)^(\s*server\s*=\s*)(\S+)(\s*)$`)
-	tidExp    = regexp.MustCompile(`(?im)^(\s*tidheader\s*=\s*X-Telemetry-TID\s*:\s*)(\S+)(\s*)$`)
 
 	eventID string
 )
@@ -89,15 +91,19 @@ type Telemetry struct {
 	userDefined bool
 }
 
-func init() {
-	// Initialize the event record ID
+// randomString generates hex string
+func randomString() (string, error) {
 	randData := make([]byte, 256)
 	_, err := rand.Read(randData)
 	if err != nil {
-		return
+		return "", err
 	}
+	return fmt.Sprintf("%x", md5.Sum(randData)), nil
+}
 
-	eventID = fmt.Sprintf("%x", md5.Sum(randData))
+func init() {
+	// Initialize the event record ID
+	eventID, _ = randomString()
 }
 
 // SetUserDefined set the user defined flag
@@ -211,13 +217,6 @@ func (tl *Telemetry) IsUsingPrivateIP() bool {
 // using the customer server and ID
 func (tl *Telemetry) CreateTelemetryConf(rootDir string) error {
 
-	defConfFile := filepath.Join(rootDir, defaultTelemetryConf)
-	// Make sure we can read the default Telemetry configuration file
-	defConf, readErr := ioutil.ReadFile(defConfFile)
-	if readErr != nil {
-		return readErr
-	}
-
 	// Ensure the customer configuration file directory exists
 	targetConfFile := filepath.Join(rootDir, customTelemetryConf)
 	targetConfDir := filepath.Dir(targetConfFile)
@@ -225,13 +224,9 @@ func (tl *Telemetry) CreateTelemetryConf(rootDir string) error {
 		return err
 	}
 
-	// Replace the telemetry server
-	targetConf := serverExp.ReplaceAll(defConf, []byte("${1}"+tl.URL+"${3}"))
-	// Replace the telemetry ID
-	targetConf = tidExp.ReplaceAll(targetConf, []byte("${1}"+tl.TID+"${3}"))
-
+	var confFile = fmt.Sprintf(configTemplate, tl.URL, tl.TID)
 	// Write the new file
-	writeErr := ioutil.WriteFile(targetConfFile, targetConf, 0644)
+	writeErr := ioutil.WriteFile(targetConfFile, []byte(confFile), 0644)
 	if writeErr != nil {
 		return writeErr
 	}
@@ -241,93 +236,22 @@ func (tl *Telemetry) CreateTelemetryConf(rootDir string) error {
 	return nil
 }
 
-// CreateLocalTelemetryConf creates a new local custom Telemetry configuration
-// file to enable the uploading of telemetry records to the remote server.
-// Necessary as we change the default hostname to localhost in the server URI
-// during image creation to ensure record caching during the install.
-func (tl *Telemetry) CreateLocalTelemetryConf() error {
-
-	// Ensure the customer configuration file directory exists
-	targetConfDir := filepath.Dir(customTelemetryConf)
-	if err := utils.MkdirAll(targetConfDir, 0755); err != nil {
-		return err
-	}
-
-	if err := utils.CopyFile(defaultTelemetryConf, customTelemetryConf); err != nil {
-		log.Warning("Failed to copy telemetry config %q", customTelemetryConf)
-	}
-
-	log.Debug("Created Local Telemetry server configuration file %q", customTelemetryConf)
-
-	return nil
-}
-
-// UpdateLocalTelemetryServer updates the local custom Telemetry configuration
-// file using the customer server and ID
-func (tl *Telemetry) UpdateLocalTelemetryServer() error {
-
-	// Make sure we can read the current custom Telemetry configuration file
-	origConf, readErr := ioutil.ReadFile(customTelemetryConf)
-	if readErr != nil {
-		return readErr
-	}
-
-	newConfFile := customTelemetryConf + ".new"
-	newConf := serverExp.ReplaceAll(origConf, []byte("${1}"+tl.URL+"${3}"))
-	// Replace the server
-	// Write the new file
-	writeErr := ioutil.WriteFile(newConfFile, newConf, 0644)
-	if writeErr != nil {
-		return writeErr
-	}
-
-	// Move the new file into place
-	moveErr := os.Rename(newConfFile, customTelemetryConf)
-	if moveErr != nil {
-		return moveErr
-	}
-
-	log.Debug("Updated local Telemetry server configuration file with URL %q and tag %q", tl.URL, tl.TID)
-
-	return nil
-}
-
-// RestartLocalTelemetryServer restart the Telemetry service
-// required after changes to the configuration file
-func (tl *Telemetry) RestartLocalTelemetryServer() error {
-	args := []string{
-		"telemctl",
-		"restart",
-	}
-
-	err := cmd.RunAndLog(args...)
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	return nil
-}
-
-// StopLocalTelemetryServer stops the Telemetry service
-func (tl *Telemetry) StopLocalTelemetryServer() error {
-	args := []string{
-		"telemctl",
-		"stop",
-	}
-
-	err := cmd.RunAndLog(args...)
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	return nil
-}
-
 // CopyTelemetryRecords copies the local spooled telemetry records
 // to the target system to be uploaded when the target system is
 // booted and telemetry is enabled.
 func (tl *Telemetry) CopyTelemetryRecords(rootDir string) error {
-	err := filepath.Walk(telemetrySpoolDir,
+	// Get directory ownership
+	spoolDirInfo, err := os.Stat(telemetrySpoolDir)
+	if err != nil {
+		return fmt.Errorf("Unable to stat %q, %s", filepath.Join(telemetrySpoolDir), err)
+	}
+	sys := spoolDirInfo.Sys()
+	stat, ok := sys.(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("Could not stat telemetry %q", telemetrySpoolDir)
+	}
+
+	err = filepath.Walk(telemetrySpoolDir,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				log.Warning("Failure accessing a path %q: %v\n", path, err)
@@ -335,28 +259,16 @@ func (tl *Telemetry) CopyTelemetryRecords(rootDir string) error {
 			}
 			target := filepath.Join(rootDir, path)
 			if info.IsDir() {
-				// Create the matching target directory
-				if err := utils.MkdirAll(target, info.Mode()); err != nil {
-					log.Warning("Failed to mkdir telemetry %q", target)
-					return err
-				}
-
+				// Telemetry spool directory is flat
 				return nil
 			}
 			if err := utils.CopyFile(path, target); err != nil {
 				log.Warning("Failed to copy telemetry %q", target)
 			}
-
 			// Ensure all contents is owned correctly
-			sys := info.Sys()
-			stat, ok := sys.(*syscall.Stat_t)
-			if ok {
-				if err := os.Chown(target, int(stat.Uid), int(stat.Gid)); err != nil {
-					log.Warning("Failed to change ownership of %q to UID:%d, GID:%d",
-						target, stat.Uid, stat.Gid)
-				}
-			} else {
-				log.Warning("Could not stat telemetry %q", path)
+			if err := os.Chown(target, int(stat.Uid), int(stat.Gid)); err != nil {
+				log.Warning("Failed to change ownership of %q to UID:%d, GID:%d",
+					target, stat.Uid, stat.Gid)
 			}
 
 			return nil
@@ -366,14 +278,13 @@ func (tl *Telemetry) CopyTelemetryRecords(rootDir string) error {
 		return fmt.Errorf("Failed to archive telemetry records")
 	}
 
-	// tar cpf - /var/spool/telemetry | (cd /tmp/a; tar xBpf - )
-
 	return nil
 }
 
-// LogRecord send a new Telemetry record to the service
+// LogRecord generates and saves a Telemetry record
 func (tl *Telemetry) LogRecord(class string, severity int, payload string) error {
 
+	w := bytes.NewBuffer(nil)
 	if severity < 1 {
 		log.Warning("Telemetry severity (%d) less than 1, defaulting to 1", severity)
 		severity = 1
@@ -396,6 +307,8 @@ func (tl *Telemetry) LogRecord(class string, severity int, payload string) error
 		fmt.Sprintf("%d", severity),
 		"--class",
 		fmt.Sprintf("%s/%s", baseClass, class),
+		"--no-post",
+		"--echo",
 	}
 	if eventID != "" {
 		args = append(args,
@@ -408,8 +321,20 @@ func (tl *Telemetry) LogRecord(class string, severity int, payload string) error
 			"--payload", payload,
 		}...)
 
-	err := cmd.RunAndLog(args...)
+	err := cmd.Run(w, args...)
 	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	recordName, err := randomString()
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	recordName = recordName[:6]
+	telemetryFilename := filepath.Join(telemetrySpoolDir, recordName)
+
+	if err := ioutil.WriteFile(telemetryFilename, w.Bytes(), 0644); err != nil {
+		log.Info(err.Error())
 		return errors.Wrap(err)
 	}
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Rework installation telemetry record generation, with this change the record creation for the results of an installation is no longer dependent on updating telemetry daemons configuration.
- Disable telemetry reporting using configuration options: ```record_server_delivery_enabled``` to disable telemetry remote reporting and ```record_retention_enabled``` to keep records local.


