### PR TITLE
tests: telemetric update for release 2.2.0

### DIFF
--- a/tests/telemetrics.conf
+++ b/tests/telemetrics.conf
@@ -1,67 +1,69 @@
+# values represent their default state
+# copy to /etc/telemetrics/telemetrics.conf and modify for user config
 [settings]
 # ip address of destination server for record delivery
-server=https://clr.telemetry.intel.com/v2/collector
+#server=https://clr.telemetry.intel.com/v2/collector
 
-socket_path=/run/telem-0
+#socket_path=/run/telem-0
 
 # certificate file to use to validate ssl endpoint
-cainfo=
+#cainfo=
 
 # Telemetry id - post header used to group records in ingestion service,
 # which may be ingesting for more than one set of clients. Can be set
 # to any string.
-tidheader=X-Telemetry-TID:\s6907c830-eed9-4ce9-81ae-76daf8d88f0f
+#tidheader=X-Telemetry-TID:\s6907c830-eed9-4ce9-81ae-76daf8d88f0f
 
 # record expiry time in minutes
-record_expiry=1200
+#record_expiry=1200
 
-spool_dir=/var/spool/telemetry
+#spool_dir=/var/spool/telemetry
 
 # maximum size of the spool directory in KB, -1 = quota disabled.
 # The block size of the files in this directory is considered,
 # and not the actual size of the record itself.
-spool_max_size=5120
+#spool_max_size=5120
 
 # time in seconds for processing spool
 # Valid range: 120..300. Values outside this range are clamped.
-spool_process_time=120
+#spool_process_time=120
 
 # rate limit enabled - if this is set to false then all rate-limiting disabled.
 # It is possible to disable each rate-limit individually below.
-rate_limit_enabled=true
+#rate_limit_enabled=true
 
 # rate limiting record burst limit
 # Valid Range:  0..INT_MAX, -1 = disabled.
-record_burst_limit=1000
+#record_burst_limit=1000
 
 # rate limiting record window length in minutes
 # Valid Range: 0..59
-record_window_length=15
+#record_window_length=15
 
 # rate limiting byte burst limit
 # Valid Range:  0..INT_MAX, -1 = disabled.
-byte_burst_limit=-1
+#byte_burst_limit=-1
 
 # rate limiting byte window length in minutes
 # Valid Range: 0..59
-byte_window_length=20
+#byte_window_length=20
 
 # rate limit strategy - what to do with record if rate-limiting prevents 
 # delivery over network
 # Valid stategies: spool, drop
-rate_limit_strategy=spool
+#rate_limit_strategy=spool
 
 # daemon recycling enabled - if daemon has been running for a while (2 hours),
 # has not any client nor spool data, then it exits.
 # this is to ensure that latest code runs.
-daemon_recycling_enabled=true
+#daemon_recycling_enabled=true
 
 # record server delivery enabled - when enabled records will be delivered
 # to server otherwise records will be ignored. This configuration can be used
 # with 'record_retention_enable' configuration value to keep records local only.
-record_server_delivery_enabled=true
+#record_server_delivery_enabled=true
 
 # record retention enabled - when enabled a copy of reported telemetry records
 # will be kept locally. This configuration combined with 'record_server_delivery_enabled'
 # value can be used to keep records local only.
-record_retention_enabled=false
+#record_retention_enabled=false


### PR DESCRIPTION
A new version of telemetrics-client now has built-in defaults for all values and the released configuration file is now all comments as a template. Updating to new configuration file release for checks.
