### PR TITLE
swupd: Require HTTPS/FILE protocol for mirror

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -123,6 +123,10 @@ func main() {
 	log.Info(path.Base(os.Args[0]) + ": " + model.Version +
 		", built on " + model.BuildDate)
 
+	if options.SwupdContentURL != "" && swupd.IsValidMirror(options.SwupdContentURL) == false {
+		fatal(errors.Errorf("swupd-contenturl %s must use HTTPS or FILE protocol", options.SwupdContentURL))
+	}
+
 	if options.PamSalt != "" {
 		hashed, errHash := encrypt.Crypt(options.PamSalt)
 		if err != nil {

--- a/gui/pages/swupd_config.go
+++ b/gui/pages/swupd_config.go
@@ -5,8 +5,6 @@
 package pages
 
 import (
-	"net/url"
-
 	"github.com/gotk3/gotk3/gtk"
 
 	"github.com/clearlinux/clr-installer/gui/common"
@@ -155,11 +153,8 @@ func NewSwupdConfigPage(controller Controller, model *model.SystemInstall) (Page
 func (page *SwupdConfigPage) onMirrorChange(entry *gtk.Entry) {
 	mirror := getTextFromEntry(entry)
 	page.mirrorWarning.SetText("")
-	if mirror != "" {
-		_, err := url.ParseRequestURI(mirror)
-		if err != nil {
-			page.mirrorWarning.SetText(utils.Locale.Get(swupd.InvalidURL))
-		}
+	if mirror != "" && swupd.IsValidMirror(mirror) == false {
+		page.mirrorWarning.SetText(utils.Locale.Get(swupd.InvalidURL))
 	}
 
 	page.setConfirmButton()

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -655,8 +655,8 @@ msgstr "Enable Auto Updates"
 msgid "WARNING: Disabling Automatic OS Updates puts the system at risk of missing critical security patches."
 msgstr "WARNING: Disabling Automatic OS Updates puts the system at risk of missing critical security patches."
 
-msgid "Invalid URL"
-msgstr "Invalid URL"
+msgid "Invalid URL: Use HTTPS"
+msgstr "Invalid URL: Use HTTPS"
 
 msgid "Mirror not set correctly"
 msgstr "Mirror not set correctly"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -655,8 +655,8 @@ msgstr "Habilitar actualizaciones automáticas"
 msgid "WARNING: Disabling Automatic OS Updates puts the system at risk of missing critical security patches."
 msgstr "ADVERTENCIA: La desactivación de las actualizaciones automáticas del sistema operativo pone al sistema en riesgo de perder parches de seguridad críticos."
 
-msgid "Invalid URL"
-msgstr "URL no válida"
+msgid "Invalid URL: Use HTTPS"
+msgstr "URL no válida: Utilizar HTTPS"
 
 msgid "Mirror not set correctly"
 msgstr "Espejo no configurado correctamente"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -655,8 +655,8 @@ msgstr "启用自动更新"
 msgid "WARNING: Disabling Automatic OS Updates puts the system at risk of missing critical security patches."
 msgstr "警告: 禁用自动操作系统更新会使系统面临丢失关键安全修补程序的风险。"
 
-msgid "Invalid URL"
-msgstr "无效 URL"
+msgid "Invalid URL: Use HTTPS"
+msgstr "无效 URL: 使用 HTTPS"
 
 msgid "Mirror not set correctly"
 msgstr "镜像设置不正确"

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -66,7 +67,7 @@ const (
 	AutoUpdateWarning2 = "missing critical security patches."
 
 	// InvalidURL specifies invalid url error message
-	InvalidURL = "Invalid URL"
+	InvalidURL = "Invalid URL: Use HTTPS"
 
 	// IncorrectMirror specifies incorrect mirror error message
 	IncorrectMirror = "Mirror not set correctly"
@@ -523,6 +524,22 @@ func UnSetHostMirror() (string, error) {
 	}
 
 	return unSetMirror(args, "Host")
+}
+
+// IsValidMirror checks for valid URIs that use the HTTPS or FILE protocol
+func IsValidMirror(mirror string) bool {
+	_, err := url.ParseRequestURI(mirror)
+	if err != nil {
+		return false
+	}
+
+	httpsPrefix := strings.HasPrefix(strings.ToLower(mirror), "https:")
+	filePrefix := strings.HasPrefix(strings.ToLower(mirror), "file:")
+	if httpsPrefix != true && filePrefix != true {
+		return false
+	}
+
+	return true
 }
 
 // checkSwupd executes the "swupd check-update" to verify connectivity

--- a/tui/swupd_mirror.go
+++ b/tui/swupd_mirror.go
@@ -5,8 +5,6 @@
 package tui
 
 import (
-	"net/url"
-
 	"github.com/VladimirMarkelov/clui"
 
 	"github.com/clearlinux/clr-installer/swupd"
@@ -86,11 +84,8 @@ func newSwupdMirrorPage(tui *Tui) (Page, error) {
 		warning := ""
 		userURL := page.swupdMirrorEdit.Title()
 
-		if userURL != "" {
-			_, err := url.ParseRequestURI(page.swupdMirrorEdit.Title())
-			if err != nil {
-				warning = swupd.InvalidURL
-			}
+		if userURL != "" && swupd.IsValidMirror(userURL) == false {
+			warning = swupd.InvalidURL
 		}
 
 		page.swupdMirrorWarning.SetTitle(warning)


### PR DESCRIPTION
Fixes Issue: #473

Changes proposed in this pull request:
- Return error when swupd-contenturl argument does not use HTTPS or FILE protocol
- Prevent gui/tui from accepting URL that is not the HTTPS or FILE protocol
- Change invalid URL string for gui/tui to suggest HTTPS: "Invalid URL" -> "Invalid URL: Use HTTPS"
- Update locales **(I am not confident in my Chinese translation, so I did not update this)**
- Mixed/Uppercase HTTP and FILE protocols are accepted (Swupd accepts Mixed/Uppercase)


