### PR TITLE
InstallerYAMLSyntax: fix cmdline bug in example

### DIFF
--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -150,7 +150,7 @@ Item | Description | Required?
 ```yaml
 kernel-arguments: {
   add: ["nomodeset", "i915.modeset=0"],
-  remove: [console=ttyS0,115200n8]
+  remove: ["console=ttyS0,115200n8"]
 }
 ```
 


### PR DESCRIPTION
The kernel-arguments example is missing a pair of quotes for the remove
field-- without the quotes, two removal entries are added to
cmdline-removal.d on installation: "console=ttyS0" and "115200n8".

The quotes ensure that a single cmdline-removal.d entry,
"console=ttyS0,115200n8", is generated at installation time on the
target.

Signed-off-by: Joe Konno <joe.konno@intel.com>