### PR TITLE
Remove bug in readme example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,6 +101,6 @@ sudo .gopath/bin/clr-installer --reboot=false
 or if using the Mass Installer mode:
 
 ```
-sudo .gopath/bin/clr-installer --config=~/my-install.yaml --reboot=false
+sudo .gopath/bin/clr-installer --config ~/my-install.yaml --reboot=false
 ```
 


### PR DESCRIPTION
The shell will not expand a `~` when it is proceeded
with an equal sign (`=`). To use `~` in a path, then be
sure to have it preceded by a space.

Fixes: 485