### PR TITLE
isoutils: fix mkInitrd install os-core-plus

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -123,8 +123,8 @@ func mkInitrd(version string, model *model.SystemInstall, options args.Args) err
 	options.SwupdFormat = "staging"
 	sw := swupd.New(tmpPaths[clrInitrd], options)
 
-	/* Install os-core only as initrd */
-	if err := sw.VerifyWithBundles(version, model.SwupdMirror, []string{}); err != nil {
+	/* Install os-core and os-core-plus (we only need kmod-bin) as initrd */
+	if err := sw.VerifyWithBundles(version, model.SwupdMirror, []string{"os-core-plus"}); err != nil {
 		prg = progress.NewLoop(msg)
 		prg.Failure()
 		return err


### PR DESCRIPTION
Since clearlinux/clr-bundles@28319f78d1bd ("os-core: Remove content
provided by os-core-plus"), **kmod** package was removed from
os-core bundle and it is shipped by os-core-plus.

Kmod package provides insmod which is used in the ISO initrd/init
script.

Use **os-core-plus** bundle as initrd base instead of os-core.