### PR TITLE
Ensure the image build has results

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -243,10 +243,6 @@ func main() {
 	if options.SwupdMirror != "" {
 		md.SwupdMirror = options.SwupdMirror
 	}
-	// If ISO not set in configuration file ensure we keep the image file
-	if !md.MakeISO {
-		md.KeepImage = true
-	}
 
 	// Command line overrides the configuration file
 	if options.MakeISOSet {
@@ -260,6 +256,10 @@ func main() {
 		if options.KeepImageSet {
 			md.KeepImage = options.KeepImage
 		}
+	}
+	// If ISO not set in configuration file ensure we keep the image file
+	if !md.MakeISO {
+		md.KeepImage = true
 	}
 
 	if !options.StubImage {


### PR DESCRIPTION
Changes proposed in this pull request:
- Bug Fix: Allow --iso=false command line argument to override the value from the YAML file ISO value, and still keep the image file which is created.


