### PR TITLE
Disable AES checks.

### DIFF
--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -65,14 +65,6 @@ have_ssse3_cpu_feature () {
     check_result "$?" "$need"
 }
 
-have_aes_cpu_feature () {
-    local feature="aes"
-    local desc="Advanced Encryption Standard instruction set"
-    local need="$desc ($feature)"
-    have_cpu_feature "$feature"
-    check_result "$?" "$need"
-}
-
 have_pclmul_cpu_feature () {
     local feature="pclmulqdq"
     local desc="Carry-less Multiplication extensions"
@@ -166,7 +158,6 @@ main() {
     have_ssse3_cpu_feature
     have_sse41_cpu_feature
     have_sse42_cpu_feature
-    have_aes_cpu_feature
     have_pclmul_cpu_feature
     echo_tty_kmsg "[${SUCCESS}  OK  ${NORMAL}] All checks passed."
 

--- a/syscheck/syscheck.go
+++ b/syscheck/syscheck.go
@@ -47,7 +47,6 @@ func RunSystemCheck(quiet bool) error {
 		"sse4_2",
 		"sse4_1",
 		"pclmulqdq",
-		"aes",
 		"ssse3",
 	}
 	for _, feature := range cpuFeatures {


### PR DESCRIPTION
We're well into disabling AES as a requirement at this point and have done the needed recompiles. At this point we're needlessly slowing down for little use - AES issues are quickly fixed if found.

