### PR TITLE
locale: switch to swupd bundle glibc-locale

### DIFF
--- a/language/language.go
+++ b/language/language.go
@@ -31,7 +31,7 @@ const (
 	DefaultLanguage = "en_US.UTF-8"
 
 	// RequiredBundle the bundle needed to set language other than the default
-	RequiredBundle = "locales"
+	RequiredBundle = "glibc-locale"
 )
 
 // validLanguages stores the list of localized languages

--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -109,7 +109,7 @@ https://github.com/clearlinux/clr-bundles
 Item | Description | Default
 ------------ | ------------- | ------------- 
 `keyboard:` | Name of the keyboard type. Valid value can be found using `localectl list-keymaps`; may require installing the `kbd` bundle first. | us
-`language:` | Name of the system language. Valid values can be found using `locale -a`; may require installing the `locales` bundle fist. | en_US.UTF-8
+`language:` | Name of the system language. Valid values can be found using `locale -a`; may require installing the `glibc-locale` bundle fist. | en_US.UTF-8
 `timezone:` | Name of the system timezone. Valid values can be found using `timedatectl list-timezones`; may require installing the `tzdata` bundle fist. | UTC
 `kernel` | Kernel bundle to be used | kernel-native
 `httpsProxy` | HTTPS Proxy as a string | `-UNDEFINED-`


### PR DESCRIPTION
Fixes Issue: #506

Changes proposed in this pull request:
- Updating the installer to use the preferred swupd bundle glibc-locale instead of locales. Both have the same definition.
