### PR TITLE
telemetry: execute additional telemetry steps

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -756,12 +756,25 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 			log.Warning("Failed to copy image Telemetry data")
 			errMsgs = append(errMsgs, "Failed to copy image Telemetry data")
 		}
-
+		log.Info("Running telemctl opt-in")
+		if err := md.Telemetry.OptIn(rootDir); err != nil {
+			log.Warning("Failed to opt-in to telemetry")
+			errMsgs = append(errMsgs, "Failed to opt-in to telemetry")
+		}
 		if len(errMsgs) > 0 {
 			return errors.Errorf("%s", strings.Join(errMsgs, ";"))
 		}
 	} else {
 		log.Info("Telemetry disabled, skipping record collection.")
+
+		log.Info("Running telemctl opt-out")
+		if err := md.Telemetry.OptOut(rootDir); err != nil {
+			log.Warning("Unable to opt-out, telemetry might not be present")
+			errMsgs = append(errMsgs, "Unable to opt-out, telemetry might not be present")
+		}
+		if len(errMsgs) > 0 {
+			return errors.Errorf("%s", strings.Join(errMsgs, ";"))
+		}
 	}
 
 	return nil

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -47,6 +47,9 @@ is collected.
 	// TelemetryAboutURL is the URL to reference for telemetry details
 	TelemetryAboutURL = `https://clearlinux.org/documentation/clear-linux/concepts/telemetry-about`
 
+	// telemetry controlling interface command
+	telemctlCmd = "telemctl"
+
 	// RequestNotice is a common text string to be displayed when enabling
 	// telemetry by default on local networks
 	RequestNotice = `NOTICE: Enabling Telemetry preferred by default on internal networks.`
@@ -345,6 +348,35 @@ func (tl *Telemetry) LogRecord(class string, severity int, payload string) error
 	}
 
 	return nil
+}
+
+// opt is a helper function
+func opt(rootDir string, optCmd string) error {
+	args := []string{
+		"chroot",
+		rootDir,
+		telemctlCmd,
+		optCmd,
+	}
+
+	err := cmd.RunAndLog(args...)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+// OptIn runs the command to opt-in to telemetry when users accept to
+// provide telemetry from crashes
+func (tl *Telemetry) OptIn(rootDir string) error {
+	return opt(rootDir, "opt-in")
+}
+
+// OptOut runs the command to opt-out to telemetry when users do not
+// agree to provide telemetry from crashes
+func (tl *Telemetry) OptOut(rootDir string) error {
+	return opt(rootDir, "opt-out")
 }
 
 // RunningEnvironment returns the name of the hypervisor if running in a

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -240,6 +240,58 @@ func TestWriteTargetConfig(t *testing.T) {
 	}
 }
 
+func TestOptIn(t *testing.T) {
+	var url string
+	tid := "MyTid"
+
+	if !utils.IsClearLinux() {
+		t.Skip("Not a Clear Linux system, skipping test")
+	}
+
+	telem := &Telemetry{
+		URL: url,
+		TID: tid,
+	}
+
+	rootDir, err := ioutil.TempDir("", "root-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		_ = os.RemoveAll(rootDir)
+	}()
+
+	// Smoke test
+	_ = telem.OptIn(rootDir)
+}
+
+func TestOptOut(t *testing.T) {
+	var url string
+	tid := "MyTid"
+
+	if !utils.IsClearLinux() {
+		t.Skip("Not a Clear Linux system, skipping test")
+	}
+
+	telem := &Telemetry{
+		URL: url,
+		TID: tid,
+	}
+
+	rootDir, err := ioutil.TempDir("", "root-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		_ = os.RemoveAll(rootDir)
+	}()
+
+	// Smoke test
+	_ = telem.OptOut(rootDir)
+}
+
 func TestFailedToWriteTargetConfig(t *testing.T) {
 	var url string
 	tid := "MyTid"


### PR DESCRIPTION
This change executes opt-in when users agree to provide crash information
to the clear linux team and opt-out when users do not agree.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>