### PR TITLE
telemetry: do not fail if bundle is not installed

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -751,18 +751,22 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 	}
 
 	if md.IsTelemetryEnabled() {
-		log.Info("Copying telemetry records to target system.")
-		if err := md.Telemetry.CopyTelemetryRecords(rootDir); err != nil {
-			log.Warning("Failed to copy image Telemetry data")
-			errMsgs = append(errMsgs, "Failed to copy image Telemetry data")
-		}
-		log.Info("Running telemctl opt-in")
-		if err := md.Telemetry.OptIn(rootDir); err != nil {
-			log.Warning("Failed to opt-in to telemetry")
-			errMsgs = append(errMsgs, "Failed to opt-in to telemetry")
-		}
-		if len(errMsgs) > 0 {
-			return errors.Errorf("%s", strings.Join(errMsgs, ";"))
+		if md.IsTelemetryInstalled() {
+			log.Info("Copying telemetry records to target system.")
+			if err := md.Telemetry.CopyTelemetryRecords(rootDir); err != nil {
+				log.Warning("Failed to copy image Telemetry data")
+				errMsgs = append(errMsgs, "Failed to copy image Telemetry data")
+			}
+			log.Info("Running telemctl opt-in")
+			if err := md.Telemetry.OptIn(rootDir); err != nil {
+				log.Warning("Failed to opt-in to telemetry")
+				errMsgs = append(errMsgs, "Failed to opt-in to telemetry")
+			}
+			if len(errMsgs) > 0 {
+				return errors.Errorf("%s", strings.Join(errMsgs, ";"))
+			}
+		} else {
+			log.Info("Telemetry is not present in the installer, skipping copying records")
 		}
 	} else {
 		log.Info("Telemetry disabled, skipping record collection.")

--- a/model/model.go
+++ b/model/model.go
@@ -484,6 +484,11 @@ func (si *SystemInstall) IsTelemetryEnabled() bool {
 	return si.Telemetry.Enabled
 }
 
+// IsTelemetryInstalled return true if telemetry tooling is present, false otherwise
+func (si *SystemInstall) IsTelemetryInstalled() bool {
+	return si.Telemetry.Installed()
+}
+
 // WriteFile writes a yaml formatted representation of si into the provided file path
 func (si *SystemInstall) WriteFile(path string) error {
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)


### PR DESCRIPTION
This change removes the need for telemetrics bundle to be present for
the installer to work.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>