### PR TITLE
gui: Preserve installation type

### DIFF
--- a/gui/pages/disk_config.go
+++ b/gui/pages/disk_config.go
@@ -934,6 +934,7 @@ func (disk *DiskConfig) GetTitle() string {
 // StoreChanges will store this pages changes into the model
 func (disk *DiskConfig) StoreChanges() {
 	var installBlockDevice *storage.BlockDevice
+	disk.saveMedias = nil
 
 	if disk.safeButton.GetActive() {
 		disk.model.ClearInstallSelected()


### PR DESCRIPTION
The installation type is now preserved when re-entering the disk config
page.

Fixes Issue: No issue filed?

Changes proposed in this pull request:
- When selecting an installation type (safe, destructive, advanced) on the GUI disk config page, the selection should be preserved properly.


