### PR TITLE
Add support to download config over network

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -222,7 +222,16 @@ func execute(options args.Args) error {
 		if cf, err = conf.LookupDefaultConfig(); err != nil {
 			return err
 		}
+	} else if network.IsValidURI(options.ConfigFile, options.AllowInsecureHTTP) {
+		if cf, err = network.FetchRemoteConfigFile(options.ConfigFile); err != nil {
+			fmt.Printf("Cannot acesss configuration file %q: %s\n", options.ConfigFile, err)
+			return err
+		}
+		options.CfDownloaded = true
+	} else {
+		return errors.Errorf("No valid configuration file")
 	}
+
 	if options.CfDownloaded {
 		defer func() { _ = os.Remove(cf) }()
 	}

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/clearlinux/clr-installer/language"
 	"github.com/clearlinux/clr-installer/log"
 	"github.com/clearlinux/clr-installer/model"
+	"github.com/clearlinux/clr-installer/network"
 	"github.com/clearlinux/clr-installer/swupd"
 	"github.com/clearlinux/clr-installer/syscheck"
 	"github.com/clearlinux/clr-installer/telemetry"
@@ -279,7 +280,7 @@ func execute(options args.Args) error {
 		md.AllowInsecureHTTP = options.AllowInsecureHTTP
 	}
 
-	if options.SwupdContentURL != "" && swupd.IsValidMirror(options.SwupdContentURL, md.AllowInsecureHTTP) == false {
+	if options.SwupdContentURL != "" && network.IsValidURI(options.SwupdContentURL, md.AllowInsecureHTTP) == false {
 		return errors.Errorf("swupd-contenturl %s must use HTTPS or FILE protocol", options.SwupdContentURL)
 	}
 

--- a/gui/pages/swupd_config.go
+++ b/gui/pages/swupd_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/clearlinux/clr-installer/gui/common"
 	"github.com/clearlinux/clr-installer/log"
 	"github.com/clearlinux/clr-installer/model"
+	"github.com/clearlinux/clr-installer/network"
 	"github.com/clearlinux/clr-installer/swupd"
 	"github.com/clearlinux/clr-installer/utils"
 )
@@ -183,7 +184,7 @@ func NewSwupdConfigPage(controller Controller, model *model.SystemInstall) (Page
 func (page *SwupdConfigPage) onMirrorChange(entry *gtk.Entry) {
 	mirror := getTextFromEntry(entry)
 	page.mirrorWarning.SetText("")
-	if mirror != "" && swupd.IsValidMirror(mirror, page.model.AllowInsecureHTTP) == false {
+	if mirror != "" && network.IsValidURI(mirror, page.model.AllowInsecureHTTP) == false {
 		page.mirrorWarning.SetText(utils.Locale.Get(swupd.InvalidURL))
 	}
 

--- a/network/network.go
+++ b/network/network.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -155,6 +156,31 @@ func IsValidDomainName(domain string) string {
 	}
 
 	return ""
+}
+
+// IsValidURI checks for valid URIs that use the HTTPS or FILE protocol
+func IsValidURI(uri string, allowInsecureHTTP bool) bool {
+	_, err := url.ParseRequestURI(uri)
+	if err != nil {
+		return false
+	}
+
+	httpsPrefix := strings.HasPrefix(strings.ToLower(uri), "https:")
+	if httpsPrefix {
+		return true
+	}
+
+	filePrefix := strings.HasPrefix(strings.ToLower(uri), "file:")
+	if filePrefix {
+		return true
+	}
+
+	httpPrefix := strings.HasPrefix(strings.ToLower(uri), "http:")
+	if httpPrefix && allowInsecureHTTP {
+		return true
+	}
+
+	return false
 }
 
 // IsUserDefined returns true if the configuration was interactively

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -43,6 +43,24 @@ func TestBadURL(t *testing.T) {
 	}
 }
 
+func TestValidURI(t *testing.T) {
+	if !IsValidURI("https://www.google.com", false) {
+		t.Fatalf("HTTPS URL failed incorrectly")
+	}
+	if !IsValidURI("file:///foo", false) {
+		t.Fatalf("FILE URL failed incorrectly")
+	}
+	if IsValidURI("http://www.google.com", false) {
+		t.Fatalf("HTTP URL with allowInsecureHTTP set to false passed incorrectly")
+	}
+	if !IsValidURI("http://www.google.com", true) {
+		t.Fatalf("HTTP URL with allowInsecureHTTP set to true failed incorrectly")
+	}
+	if IsValidURI("ftp://www.google.com", false) {
+		t.Fatalf("FTP URL passed incorrectly")
+	}
+}
+
 func TestIpAddress(t *testing.T) {
 	tests := []struct {
 		addr     string

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -614,31 +613,6 @@ func UnSetHostMirror() (string, error) {
 	}
 
 	return unSetMirror(args, "Host")
-}
-
-// IsValidMirror checks for valid URIs that use the HTTPS or FILE protocol
-func IsValidMirror(mirror string, allowInsecureHTTP bool) bool {
-	_, err := url.ParseRequestURI(mirror)
-	if err != nil {
-		return false
-	}
-
-	httpsPrefix := strings.HasPrefix(strings.ToLower(mirror), "https:")
-	if httpsPrefix {
-		return true
-	}
-
-	filePrefix := strings.HasPrefix(strings.ToLower(mirror), "file:")
-	if filePrefix {
-		return true
-	}
-
-	httpPrefix := strings.HasPrefix(strings.ToLower(mirror), "http:")
-	if httpPrefix && allowInsecureHTTP {
-		return true
-	}
-
-	return false
 }
 
 // checkSwupd executes the "swupd check-update" to verify connectivity

--- a/tui/swupd_mirror.go
+++ b/tui/swupd_mirror.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/VladimirMarkelov/clui"
 
+	"github.com/clearlinux/clr-installer/network"
 	"github.com/clearlinux/clr-installer/swupd"
 )
 
@@ -66,7 +67,7 @@ func (page *SwupdMirrorPage) validateMirror() {
 	warning := ""
 	userURL := page.swupdMirrorEdit.Title()
 
-	if userURL != "" && swupd.IsValidMirror(userURL, page.getModel().AllowInsecureHTTP) == false {
+	if userURL != "" && network.IsValidURI(userURL, page.getModel().AllowInsecureHTTP) == false {
 		warning = swupd.InvalidURL
 	}
 


### PR DESCRIPTION
When passing a config file URL to the --config flag, the installer will
download and consume the config. For example:

clr-installer --config https://pathToConfig.yaml

Signed-off-by: John Akre <john.w.akre@intel.com>

Fixes Issue: #524

Changes proposed in this pull request:
- Support URL arguments to --config flag
- Move IsValidMirror to the network package and rename ot IsValidUrl

