### PR TITLE
Refactor main to handle errors without panics 

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -129,7 +129,7 @@ func main() {
 
 	if options.PamSalt != "" {
 		hashed, errHash := encrypt.Crypt(options.PamSalt)
-		if err != nil {
+		if errHash != nil {
 			panic(errHash)
 		}
 


### PR DESCRIPTION
Fixes Issue: #547

Changes proposed in this pull request:
- Refactor main so that it is a small function that is only responsible for calling the execute function,
logging failures, and returning the exit status.
- Correctly return error when `encrypt.Crypt` fails


