### PR TITLE
Update to latest when version is 0

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -94,7 +94,7 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 	}
 
 	if model.Version == 0 {
-		version = utils.ClearVersion
+		version = "latest"
 	} else {
 		version = fmt.Sprintf("%d", model.Version)
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -493,6 +493,7 @@ func contentInstall(rootDir string, version string, md *model.SystemInstall, opt
 		if err := utils.ParseOSClearVersion(); err != nil {
 			return prg, err
 		}
+		log.Info("Overriding version from %s to %s to enable offline install", version, utils.ClearVersion)
 		version = utils.ClearVersion
 
 		// Copying offline content here is a performance optimization and is not a hard

--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -122,7 +122,7 @@ Item | Description | Default
 `swupdMirror` | URL of the swupd stream to use. Useful for installing from a local mirror or from a locally published mix. | `-UNDEFINED-`
 `allowInsecureHttp` | Allow installation over insecure connections | false
 `hostname` | Name of the host system | `-UNIQUE RANDOM-`
-`version` | Version of Clear Linux OS to install | `-VERSION_ON_BUILD_SYSTEM-`
+`version` | Version of Clear Linux OS to install | `-LATEST_VERSION-`
 `autoUpdate` | Should the system automatically update to the latest release of Clear Linux OS as part of the installation?; true or false | true
 `offline` | Install update content for minimal offline installation | false
 `postReboot` | Should the system reboot after the installation completes?; true or false | true


### PR DESCRIPTION
When the version field in the config file is set to 0, the latest
version will be installed instead of the host's version.

Fixes Issue: #502

Changes proposed in this pull request:
- The default version is the latest mix version. Previously, the default version was the host's version. 


