### PR TITLE
gui: Correctly set advanced disk config warnings

### DIFF
--- a/gui/pages/disk_config.go
+++ b/gui/pages/disk_config.go
@@ -90,7 +90,13 @@ func (disk *DiskConfig) advancedButtonToggled() {
 	results := storage.DesktopValidateAdvancedPartitions(disk.model.TargetMedias)
 	if len(results) > 0 {
 		disk.model.ClearInstallSelected()
-		disk.model.TargetMedias = nil
+
+		// When the advanced button is toggled by GetConfiguredValue(), the TargetMedias
+		// value must not be overwritten by this callback function. In this case, the
+		// advanced button will not be in focus.
+		if disk.advancedButton.IsFocus() {
+			disk.model.TargetMedias = nil
+		}
 		// display the result warnings -- with warning color
 		warning := strings.Join(results, ", ")
 		log.Warning("Advanced Partition: " + warning)
@@ -1072,6 +1078,12 @@ func (disk *DiskConfig) refreshPage() {
 		disk.destructiveButton.SetActive(true)
 	} else if disk.isAdvancedSelected {
 		disk.advancedButton.SetActive(true)
+
+		// The advanced disk media must be scanned to set TargetMedias
+		// which will be validated during the advancedButtonToggled()
+		if err := disk.buildMediaLists(); err != nil {
+			log.Warning("Problem with buildMediaLists")
+		}
 		if !advEncryption {
 			disk.encryptCheck.SetActive(false)
 			disk.encryptCheck.SetSensitive(false)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -680,6 +680,13 @@ func listBlockDevices(userDefined []*BlockDevice) ([]*BlockDevice, error) {
 		log.Warning("PartProbe has non-zero exit status: %s", err)
 	}
 
+	// Modified devices must be synchronized with udev before calling lsblk
+	args = []string{"udevadm", "settle", "--timeout", "10"}
+	err = cmd.RunAndLog(args...)
+	if err != nil {
+		log.Warning("udevadm has non-zero exit status: %s", err)
+	}
+
 	// Exclude memory(1), floppy(2), and SCSI CDROM(11) devices
 	err = cmd.Run(w, lsblkBinary, "--exclude", "1,2,11", "-J", "-b", "-O")
 	if err != nil {


### PR DESCRIPTION
When using advanced disk partitioning with an invalid setup and loading
the menu page or disk configuration page for the first time, the warning
messages were not set correctly. The warnings were incorrectly set
because the TargetMedias variable was unexpectedly overwritten to nil.
This change prevents unexpected overwrites of TargetMedias and sets
TargetMedias when it is uninitialized.

Fixes: #553

Changes proposed in this pull request:
- Correctly set menu disk config warning when incorrectly setting advanced disk partitioning
- Correctly set disk config warning when incorrectly setting advanced disk partitioning


