### PR TITLE
Fix early exit in utils.ExpandVariables

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -246,13 +246,9 @@ func ExpandVariables(vars map[string]string, str string) string {
 	for k, v := range vars {
 		// tries to replace both ${var} and $var forms
 		for _, rep := range []string{fmt.Sprintf("$%s", k), fmt.Sprintf("${%s}", k)} {
-			if strings.Contains(str, rep) {
-				return strings.Replace(str, rep, v, -1)
-			}
+			str = strings.ReplaceAll(str, rep, v)
 		}
 	}
-
-	// if no variables are expanded return the original string
 	return str
 }
 


### PR DESCRIPTION
ExpandVariables was returning early, upon first variable expansion, instead of expanding all available variables.

Also removed unnecessary strings.Contains check as strings.ReplaceAll performs a similar check internally before operating.

Fixes Issue: #579
