### PR TITLE
Remove telemctl from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ before_script:
     - docker exec -it clear-test bash -c "swupd info"
       # Debug information
     - docker exec -it clear-test bash -c "set;printenv"
-      # Force restart telemetry
-    - docker exec -it clear-test bash -c "telemctl restart"
       # Debug information to verify restart
     - docker exec -it clear-test bash -c "journalctl|cat"
 


### PR DESCRIPTION
The docker image used by travis doesn't have telemctl by default any more and telemetry is optional for the installer. This change removes the call to telemctl.