### PR TITLE
Remove kbd and glibc-locale dependencies

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -349,20 +349,34 @@ func execute(options args.Args) error {
 		}
 	}
 
+	// The kbd bundle is an also-add and may be removed
 	if md.Keyboard != nil && !keyboard.IsValidKeyboard(md.Keyboard) {
-		return fmt.Errorf("Invalid Keyboard '%s'", md.Keyboard.Code)
+		msg := fmt.Sprintf("Warning: Host failed to validate keyboard: %s, using %s",
+			md.Keyboard.Code,
+			keyboard.DefaultKeyboard)
+
+		fmt.Println(msg)
+		log.Warning(msg)
+		md.Keyboard.Code = keyboard.DefaultKeyboard
 	}
 
 	if md.Timezone != nil && !timezone.IsValidTimezone(md.Timezone) {
 		return fmt.Errorf("Invalid Time Zone '%s'", md.Timezone.Code)
 	}
 
+	// The glibc-locale bundle is an also-add and may be removed
 	if md.Language != nil && !language.IsValidLanguage(md.Language) {
-		return fmt.Errorf("Invalid Language '%s'", md.Language.Code)
-	}
+		msg := fmt.Sprintf("Warning: Host failed to validate language: %s, using %s",
+			md.Language.Code,
+			language.DefaultLanguage)
 
-	// Set locale
-	utils.SetLocale(md.Language.Code)
+		fmt.Println(msg)
+		log.Warning(msg)
+		md.Language.Code = language.DefaultLanguage
+	} else {
+		// Set locale
+		utils.SetLocale(md.Language.Code)
+	}
 
 	// Run system check and exit
 	if options.SystemCheck {


### PR DESCRIPTION
The validation errors for the keyboard and language settings have been
changed to warnings. This enables the kbd and glibc-locale bundles to
be set as optional in the clr-installer bundle definition.

When the kbd and glibc-locale bundles are not installed on the host
system, the tui/gui will not populate the list of alternate keyboards
and locales and the mass installer will display a warning that it was
unable to validate the keyboard or locale.

Fixes Issue: Reduces bundle definition requirements

Changes proposed in this pull request:
- Remove kbd and glibc-locale bundle dependencies on host system. They will become also-adds in the bundle definition.
- Mass Installer: keyboard and locale validation failures will become warnings instead of fatal errors.
- TUI/GUI: The list of available keyboards and languages will be reduced (english only) when the kbd and glibc-locale bundles are not present on the host.


