### PR TITLE
swupd: Support skipping optional bundles

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -52,6 +52,8 @@ type Args struct {
 	AllowInsecureHTTP       bool
 	AllowInsecureHTTPSet    bool
 	CryptPassFile           string
+	SwupdSkipOptional       bool
+	SwupdSkipOptionalSet    bool
 	SwupdMirror             string
 	SwupdStateDir           string
 	SwupdCertPath           string
@@ -261,6 +263,10 @@ func (args *Args) setCommandLineArgs() (err error) {
 	)
 
 	flag.BoolVar(
+		&args.SwupdSkipOptional, "swupd-skip-optional", false, "Swupd --skip-optional; don't install optionally included bundles",
+	)
+
+	flag.BoolVar(
 		&args.Archive, "archive", true, "Archive data to target after finishing",
 	)
 
@@ -346,6 +352,13 @@ func (args *Args) setCommandLineArgs() (err error) {
 	if fflag != nil {
 		if fflag.Changed {
 			args.AllowInsecureHTTPSet = true
+		}
+	}
+
+	fflag = flag.Lookup("swupd-skip-optional")
+	if fflag != nil {
+		if fflag.Changed {
+			args.SwupdSkipOptionalSet = true
 		}
 	}
 

--- a/args/args.go
+++ b/args/args.go
@@ -320,7 +320,39 @@ func (args *Args) setCommandLineArgs() (err error) {
 		_ = os.Remove(saveConfigFile)
 	}
 
-	fflag = flag.Lookup("telemetry")
+	// Determine whether boolean command line arguments were set or not
+	args.setBoolFlagCheck()
+
+	if (args.TelemetryURL != "" && args.TelemetryTID == "") ||
+		(args.TelemetryURL == "" && args.TelemetryTID != "") {
+		return errors.New("Telemetry requires both --telemetry-url and --telemetry-tid")
+	}
+
+	if args.SwupdURL != "" {
+		if args.SwupdMirror != "" {
+			return errors.New("--swupd-url and --swupd-mirror are mutually exclusive")
+		}
+
+		if args.SwupdContentURL == "" {
+			args.SwupdContentURL = args.SwupdURL
+		} else {
+			fmt.Printf("Warning: --swupd-contenturl overrides --swupd-url\n")
+		}
+
+		if args.SwupdVersionURL == "" {
+			args.SwupdVersionURL = args.SwupdURL
+		} else {
+			fmt.Printf("Warning: --swupd-versionurl overrides --swupd-url\n")
+		}
+	}
+
+	return nil
+}
+
+// setBoolFlagCheck determines whether or not boolean arguments were set on
+// the command line
+func (args *Args) setBoolFlagCheck() {
+	fflag := flag.Lookup("telemetry")
 	if fflag != nil {
 		if fflag.Changed {
 			args.TelemetrySet = true
@@ -381,31 +413,6 @@ func (args *Args) setCommandLineArgs() (err error) {
 			args.KeepImageSet = true
 		}
 	}
-
-	if (args.TelemetryURL != "" && args.TelemetryTID == "") ||
-		(args.TelemetryURL == "" && args.TelemetryTID != "") {
-		return errors.New("Telemetry requires both --telemetry-url and --telemetry-tid")
-	}
-
-	if args.SwupdURL != "" {
-		if args.SwupdMirror != "" {
-			return errors.New("--swupd-url and --swupd-mirror are mutually exclusive")
-		}
-
-		if args.SwupdContentURL == "" {
-			args.SwupdContentURL = args.SwupdURL
-		} else {
-			fmt.Printf("Warning: --swupd-contenturl overrides --swupd-url\n")
-		}
-
-		if args.SwupdVersionURL == "" {
-			args.SwupdVersionURL = args.SwupdURL
-		} else {
-			fmt.Printf("Warning: --swupd-versionurl overrides --swupd-url\n")
-		}
-	}
-
-	return nil
 }
 
 // ParseArgs will both parse the command line arguments to the program

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -434,6 +434,9 @@ func TestKernelAndCommandlineAllArgs(t *testing.T) {
 	if testArgs.SwupdMirror != "" {
 		t.Errorf("Command Line 'mirror' is not defaulted to ''")
 	}
+	if testArgs.SwupdSkipOptional != false {
+		t.Errorf("Command Line '--swupd-skip-optional' is not defaulted to 'false'")
+	}
 	if testArgs.SwupdVersion != "" {
 		t.Errorf("Command Line 'swupd-version' is not defaulted to ''")
 	}

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -290,6 +290,9 @@ func execute(options args.Args) error {
 	if options.SwupdFormat != "" {
 		md.SwupdFormat = options.SwupdFormat
 	}
+	if options.SwupdSkipOptionalSet {
+		md.SwupdSkipOptional = options.SwupdSkipOptional
+	}
 	if options.SwupdVersion != "" {
 		if strings.EqualFold(options.SwupdVersion, "latest") {
 			md.Version = 0

--- a/model/model.go
+++ b/model/model.go
@@ -66,6 +66,7 @@ type SystemInstall struct {
 	PostReboot        bool                             `yaml:"postReboot,omitempty,flow"`
 	SwupdMirror       string                           `yaml:"swupdMirror,omitempty,flow"`
 	AllowInsecureHTTP bool                             `yaml:"AllowInsecureHTTP,omitempty,flow"`
+	SwupdSkipOptional bool                             `yaml:"swupdSkipOptional,omitempty,flow"`
 	PostArchive       bool                             `yaml:"postArchive,omitempty,flow"`
 	Hostname          string                           `yaml:"hostname,omitempty,flow"`
 	AutoUpdate        bool                             `yaml:"autoUpdate,flow"`

--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -124,6 +124,7 @@ Item | Description | Default
 `version` | Version of Clear Linux OS to install | `-LATEST_VERSION-`
 `swupdFormat` | swupd format to use for the installation. | `-FORMART_ON_BUILD_SYSTEM-`
 `swupdMirror` | URL of the swupd stream to use. Useful for installing from a local mirror or from a locally published mix. | `-UNDEFINED-`
+`swupdSkipOptional` | Don't install optionally included bundles; true or false | false
 `autoUpdate` | Should the system automatically update to the latest release of Clear Linux OS as part of the installation?; true or false | true
 `offline` | Install update content for minimal offline installation | false
 `postReboot` | Should the system reboot after the installation completes?; true or false | true

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -107,6 +107,7 @@ type SoftwareUpdater struct {
 	downloadOnly       bool
 	skipDiskSpaceCheck bool
 	allowInsecureHTTP  bool
+	skipOptional       bool
 }
 
 // Bundle maps a map name and description with the actual checkbox
@@ -265,6 +266,7 @@ func New(rootDir string, options args.Args, model *model.SystemInstall) *Softwar
 		downloadOnly,
 		options.SwupdSkipDiskSpaceCheck,
 		model.AllowInsecureHTTP,
+		model.SwupdSkipOptional,
 	}
 }
 
@@ -283,6 +285,10 @@ func (s *SoftwareUpdater) setExtraFlags(args []string) []string {
 
 	if s.format != "" {
 		args = append(args, fmt.Sprintf("--format=%s", s.format))
+	}
+
+	if s.skipOptional {
+		args = append(args, "--skip-optional")
 	}
 
 	if s.stateDirCache != "" {


### PR DESCRIPTION
Optionally included bundles (also-add) can now be omitted from the
install target by passing the --swupd-skip-optional flag or by setting
the swupdSkipOptional field in the config file.

Changes proposed in this pull request:
- Add flag/config field to omit optional bundles from install target
