### PR TITLE
pxe: Block service if no config file

### DIFF
--- a/etc/systemd/clr-installer-provision.service
+++ b/etc/systemd/clr-installer-provision.service
@@ -18,7 +18,9 @@ Conflicts=getty@tty1.service getty@tty0.service serial-getty@ttyS0.service
 
 [Service]
 Type=oneshot
-ExecStartPre=-/bin/bash -l -c '/usr/bin/sleep 10 && /usr/bin/cat /etc/issue'
+ExecStartPre=/bin/bash -l -c 'grep --quiet --no-message clri.descriptor= /proc/cmdline || (echo "Missing clr-install YAML on kernel command line" ; /bin/false)'
+ExecStartPre=-/bin/bash -l -c '/usr/bin/sleep 10'
+ExecStartPre=-/bin/bash -l -c '/usr/bin/cat /etc/issue'
 ExecStart=/bin/bash -l -c 'until /usr/bin/clr-installer ; do echo "clr-installer failed...retying"; sleep 5 ; done ; /usr/bin/reboot'
 StandardInput=tty
 StandardOutput=tty


### PR DESCRIPTION
Changes proposed in this pull request:
- Gate service on configuration file on kernel boot params



