### PR TITLE
Skip ISO generation if additional kernels are present

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -479,6 +479,21 @@ func contentInstall(rootDir string, version string, md *model.SystemInstall, opt
 
 	sw := swupd.New(rootDir, options, md)
 
+	// Currently, ISO image generation supports only a single kernel.
+	// Hence, skip ISO generation if multiple kernel bundles are present.
+	// TODO: Remove this logic when ISO generation supports multiple kernels.
+	if md.MakeISO {
+		for _, curr := range md.Bundles {
+			if strings.HasPrefix(curr, "kernel-") {
+				msg := "ISO image generation supports only a single kernel. Setting ISO generation to false.\n"
+				log.Warning(msg)
+				fmt.Printf("Warning: %s", msg)
+				md.MakeISO = false
+				break
+			}
+		}
+	}
+
 	bundles := md.Bundles
 
 	if md.Kernel.Bundle != "none" {


### PR DESCRIPTION
Currently, ISO image generation supports only a single kernel.
Hence, skip ISO generation if multiple kernel bundles are present.

In case the user specifies multiple kernel bundles in the `bundles` config parameter, along with setting the `iso` parameter to true:
- skip ISO generation with a warning message

Signed-off-by: Reagan Lopez <reaganlo@clearlinux-dev-01.jf.intel.com>

