### PR TITLE
storage: Add RAID type to known list

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -105,6 +105,24 @@ const (
 	// BlockDeviceTypeLVM2Volume identifies a BlockDevice as a lvm2 volume
 	BlockDeviceTypeLVM2Volume
 
+	// BlockDeviceTypeRAID0 identifies a BlockDevice as a RAID0
+	BlockDeviceTypeRAID0
+
+	// BlockDeviceTypeRAID1 identifies a BlockDevice as a RAID1
+	BlockDeviceTypeRAID1
+
+	// BlockDeviceTypeRAID4 identifies a BlockDevice as a RAID4
+	BlockDeviceTypeRAID4
+
+	// BlockDeviceTypeRAID5 identifies a BlockDevice as a RAID5
+	BlockDeviceTypeRAID5
+
+	// BlockDeviceTypeRAID6 identifies a BlockDevice as a RAID6
+	BlockDeviceTypeRAID6
+
+	// BlockDeviceTypeRAID10 identifies a BlockDevice as a RAID10
+	BlockDeviceTypeRAID10
+
 	// BlockDeviceTypeCrypt identifies a BlockDevice as an encrypted partition (created with cryptsetup)
 	BlockDeviceTypeCrypt
 
@@ -193,6 +211,12 @@ var (
 		BlockDeviceTypeRom:        "rom",
 		BlockDeviceTypeLVM2Group:  "LVM2_member",
 		BlockDeviceTypeLVM2Volume: "lvm",
+		BlockDeviceTypeRAID0:      "raid0",
+		BlockDeviceTypeRAID1:      "raid1",
+		BlockDeviceTypeRAID4:      "raid4",
+		BlockDeviceTypeRAID5:      "raid5",
+		BlockDeviceTypeRAID6:      "raid6",
+		BlockDeviceTypeRAID10:     "raid10",
 		BlockDeviceTypeUnknown:    "",
 	}
 	aliasPrefixTable = map[string]string{

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -500,6 +500,36 @@ func TestNullRemovable(t *testing.T) {
 	}
 }
 
+func TestRAID(t *testing.T) {
+	lsblkOutput := `{
+   "blockdevices": [
+      {"name":"sdb", "kname":"sdb", "path":"/dev/sdb", "maj:min":"8:16", "fsavail":null, "fssize":null, "fstype":null, "fsused":null, "fsuse%":null, "mountpoint":null, "label":null, "pttype":"gpt", "parttype":null, "partlabel":null, "ra":1024, "ro":false, "rm":false, "hotplug":false, "size":1000204886016, "state":"running", "owner":"root", "group":"disk", "mode":"brw-rw----", "alignment":0, "min-io":4096, "opt-io":0, "phy-sec":4096, "log-sec":512, "rota":false, "sched":"bfq", "rq-size":1024, "type":"disk", "disc-aln":0, "disc-gran":4096, "disc-max":2147450880, "disc-zero":false, "wsame":0, "wwn":"0x500a0751e1eda080", "rand":true, "pkname":null, "hctl":"7:0:0:0", "tran":"sata", "subsystems":"block:scsi:pci", "rev":"023 ", "vendor":"ATA     ", "zoned":"none",
+         "children": [
+            {"name":"sdb1", "kname":"sdb1", "path":"/dev/sdb1", "maj:min":"8:17", "fsavail":null, "fssize":null, "fstype":"linux_raid_member", "fsused":null, "fsuse%":null, "mountpoint":null, "label":"localhost-live:home", "pttype":"gpt", "parttype":"a19d880f-05fc-4d3b-a006-743f0f84911e", "partlabel":null, "partflags":null, "ra":1024, "ro":false, "rm":false, "hotplug":false, "size":1000203091968, "state":null, "owner":"root", "group":"disk", "mode":"brw-rw----", "alignment":0, "min-io":4096, "opt-io":0, "phy-sec":4096, "log-sec":512, "rota":false, "sched":"bfq", "rq-size":1024, "type":"part", "disc-aln":0, "disc-gran":4096, "disc-max":2147450880, "disc-zero":false, "wsame":0, "wwn":"0x500a0751e1eda080", "rand":true, "pkname":"sdb", "hctl":null, "tran":null, "subsystems":"block:scsi:pci", "rev":null, "vendor":null, "zoned":"none",
+               "children": [
+                  {"name":"md127", "kname":"md127", "path":"/dev/md127", "maj:min":"9:127", "fsavail":"4790297608192", "fssize":"4998202130432", "fstype":"xfs", "fsused":"207904522240", "fsuse%":"4%", "mountpoint":"/home", "label":"home", "pttype":null, "parttype":null, "partlabel":null, "partflags":null, "ra":5120, "ro":false, "rm":false, "hotplug":false, "size":5000339128320, "state":null, "owner":"root", "group":"disk", "mode":"brw-rw----", "alignment":0, "min-io":524288, "opt-io":2621440, "phy-sec":4096, "log-sec":512, "rota":false, "sched":null, "rq-size":128, "type":"raid5", "disc-aln":0, "disc-gran":4194304, "disc-max":2147450880, "disc-zero":false, "wsame":0, "wwn":null, "rand":false, "pkname":"sdb1", "hctl":null, "tran":null, "subsystems":"block", "rev":null, "vendor":null, "zoned":"none"}
+               ]
+            }
+         ]
+      },
+      {"name":"sdc", "kname":"sdc", "path":"/dev/sdc", "maj:min":"8:32", "fsavail":null, "fssize":null, "fstype":null, "fsused":null, "fsuse%":null, "mountpoint":null, "label":null, "pttype":"gpt", "parttype":null, "partlabel":null, "partflags":null, "ra":1024, "ro":false, "rm":false, "hotplug":false, "size":1000204886016, "state":"running", "owner":"root", "group":"disk", "mode":"brw-rw----", "alignment":0, "min-io":4096, "opt-io":0, "phy-sec":4096, "log-sec":512, "rota":false, "sched":"bfq", "rq-size":1024, "type":"disk", "disc-aln":0, "disc-gran":4096, "disc-max":2147450880, "disc-zero":false, "wsame":0, "wwn":"0x500a0751e1f0f6eb", "rand":true, "pkname":null, "hctl":"8:0:0:0", "tran":"sata", "subsystems":"block:scsi:pci", "rev":"023 ", "vendor":"ATA     ", "zoned":"none",
+         "children": [
+            {"name":"sdc1", "kname":"sdc1", "path":"/dev/sdc1", "maj:min":"8:33", "fsavail":null, "fssize":null, "fstype":"linux_raid_member", "fsused":null, "fsuse%":null, "mountpoint":null, "label":"localhost-live:home", "pttype":"gpt", "parttype":"a19d880f-05fc-4d3b-a006-743f0f84911e", "partlabel":null, "partflags":null, "ra":1024, "ro":false, "rm":false, "hotplug":false, "size":1000203091968, "state":null, "owner":"root", "group":"disk", "mode":"brw-rw----", "alignment":0, "min-io":4096, "opt-io":0, "phy-sec":4096, "log-sec":512, "rota":false, "sched":"bfq", "rq-size":1024, "type":"part", "disc-aln":0, "disc-gran":4096, "disc-max":2147450880, "disc-zero":false, "wsame":0, "wwn":"0x500a0751e1f0f6eb", "rand":true, "pkname":"sdc", "hctl":null, "tran":null, "subsystems":"block:scsi:pci", "rev":null, "vendor":null, "zoned":"none",
+               "children": [
+                  {"name":"md127", "kname":"md127", "path":"/dev/md127", "maj:min":"9:127", "fsavail":"4790297608192", "fssize":"4998202130432", "fstype":"xfs", "fsused":"207904522240", "fsuse%":"4%", "mountpoint":"/home", "label":"home", "pttype":null, "parttype":null, "partlabel":null, "partflags":null, "ra":5120, "ro":false, "rm":false, "hotplug":false, "size":5000339128320, "state":null, "owner":"root", "group":"disk", "mode":"brw-rw----", "alignment":0, "min-io":524288, "opt-io":2621440, "phy-sec":4096, "log-sec":512, "rota":false, "sched":null, "rq-size":128, "type":"raid5", "disc-aln":0, "disc-gran":4194304, "disc-max":2147450880, "disc-zero":false, "wsame":0, "wwn":null, "rand":false, "pkname":"sdc1", "hctl":null, "tran":null, "subsystems":"block", "rev":null, "vendor":null, "zoned":"none"}
+               ]
+            }
+         ]
+      }
+   ]
+}`
+
+	_, err := parseBlockDevicesDescriptor([]byte(lsblkOutput))
+	if err != nil {
+		t.Fatalf("Could not parser block device descriptor: %s", err)
+	}
+}
+
 func TestWritePartition(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "test-image-")
 	if err != nil {


### PR DESCRIPTION
Fixes Issue: #609

Changes proposed in this pull request:
- Parse RAID device types on host system; still not valid for install target



