### PR TITLE
Allow skipping swupd configuration file copy

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -89,6 +89,8 @@ type Args struct {
 	KeepImageSet            bool
 	SystemCheck             bool
 	CopyNetwork             bool
+	CopySwupd               bool
+	CopySwupdSet            bool
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -368,6 +370,10 @@ func (args *Args) setCommandLineArgs() (err error) {
 		&args.CopyNetwork, "copy-network", true, "Copy the network interface configuration files to target",
 	)
 
+	flag.BoolVar(
+		&args.CopySwupd, "copy-swupd", false, "Copy /etc/swupd configuration files to target [interactive=true]",
+	)
+
 	spflag.ErrHelp = errors.New("Clear Linux Installer program")
 
 	saveConfigFile := args.ConfigFile
@@ -471,6 +477,13 @@ func (args *Args) setBoolFlagCheck(flag *spflag.FlagSet) {
 	if fflag != nil {
 		if fflag.Changed {
 			args.KeepImageSet = true
+		}
+	}
+
+	fflag = flag.Lookup("copy-swupd")
+	if fflag != nil {
+		if fflag.Changed {
+			args.CopySwupdSet = true
 		}
 	}
 }

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -505,7 +505,7 @@ func TestCheckAllBooleans(t *testing.T) {
 	os.Args = []string{currArgs[0], currArgs[1], currArgs[2],
 		"--demo", "--telemetry", "--reboot",
 		"--iso", "--keep-image", "--allow-insecure-http", "--offline",
-		"--cfPurge", "--swupd-skip-optional", "--archive",
+		"--cfPurge", "--swupd-skip-optional", "--archive", "--copy-swupd",
 	}
 	t.Logf("Current os.Args: %v", os.Args)
 
@@ -524,7 +524,7 @@ func TestCheckAllBooleansFalse(t *testing.T) {
 	os.Args = []string{currArgs[0], currArgs[1], currArgs[2],
 		"--demo=0", "--telemetry=0", "--reboot=0",
 		"--iso=0", "--keep-image=0", "--allow-insecure-http=0", "--offline=0",
-		"--cfPurge=0", "--swupd-skip-optional=0", "--archive=0",
+		"--cfPurge=0", "--swupd-skip-optional=0", "--archive=0", "--copy-swupd=0",
 	}
 	t.Logf("Current os.Args: %v", os.Args)
 

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -254,6 +254,9 @@ func execute(options args.Args) error {
 			}
 		}
 	}
+	if options.CopySwupdSet {
+		md.CopySwupd = options.CopySwupd
+	}
 
 	if options.AllowInsecureHTTPSet {
 		md.AllowInsecureHTTP = options.AllowInsecureHTTP

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -409,7 +409,9 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		}
 	}
 
-	swupd.CopyConfigurations(rootDir)
+	if model.CopySwupd {
+		swupd.CopyConfigurations(rootDir)
+	}
 
 	if model.AllowInsecureHTTP {
 		swupd.CreateConfig(rootDir)

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -73,6 +73,12 @@ func (gui *Gui) Run(md *model.SystemInstall, rootDir string, options args.Args) 
 	// configurations to the target system
 	md.CopyNetwork = options.CopyNetwork
 
+	// When using the Interactive Installer we want to copy configurations
+	// from /etc/swupd by default to the target system
+	if !options.CopySwupdSet {
+		md.CopySwupd = true
+	}
+
 	// Use dark theming if available to differentiate from other apps
 	st, err := gtk.SettingsGetDefault()
 	if err != nil {

--- a/model/model.go
+++ b/model/model.go
@@ -81,6 +81,7 @@ type SystemInstall struct {
 	StorageAlias      []*StorageAlias                  `yaml:"block-devices,omitempty,flow"`
 	LegacyBios        bool                             `yaml:"legacyBios,omitempty,flow"`
 	CopyNetwork       bool                             `yaml:"copyNetwork,omitempty,flow"`
+	CopySwupd         bool                             `yaml:"copySwupd,omitempty,flow"`
 	Environment       map[string]string                `yaml:"env,omitempty,flow"`
 	CryptPass         string                           `yaml:"-"`
 	MakeISO           bool                             `yaml:"iso,omitempty,flow"`

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Intel Corporation
+// Copyright © 2019 Intel Corporation
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -36,6 +36,8 @@ func TestLoadFile(t *testing.T) {
 		file  string
 		valid bool
 	}{
+		{"baseline.yaml", true},
+		{"image-generation.yaml", true},
 		{"basic-invalid-descriptor.yaml", false},
 		{"basic-valid-descriptor.yaml", true},
 		{"invalid-no-keyboard.yaml", false},

--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -122,6 +122,7 @@ Item | Description | Default
 `allowInsecureHttp` | Allow installation and downloads over insecure connections | false
 `hostname` | Name of the host system | `-UNIQUE RANDOM-`
 `version` | Version of Clear Linux OS to install | `-LATEST_VERSION-`
+`copySwupd` | Copy /etc/swupd configuration files to target | false (true for user-interface installs)
 `swupdFormat` | swupd format to use for the installation. | `-FORMART_ON_BUILD_SYSTEM-`
 `swupdMirror` | URL of the swupd stream to use. Useful for installing from a local mirror or from a locally published mix. | `-UNDEFINED-`
 `swupdSkipOptional` | Don't install optionally included bundles; true or false | false

--- a/tests/image-generation.yaml
+++ b/tests/image-generation.yaml
@@ -1,0 +1,55 @@
+#clear-linux-config
+
+# c-basic-offset: 2; tab-width: 2; indent-tabs-mode: nil
+# vi: set shiftwidth=2 tabstop=2 expandtab:
+# :indentSize=2:tabSize=2:noTabs=true:
+
+# File:         image-generation.yaml
+# Use Case:     Image file for basic functionality testing.
+#               Initially create for use by swupd-client as a validation.
+
+# switch between aliases if you want to install to an actual block device
+# i.e /dev/sda
+block-devices: [
+   {name: "image-gen", file: "image-gen.img"}
+]
+
+targetMedia:
+- name: ${baseimg}
+  type: disk
+  children:
+  - name: ${baseimg}1
+    fstype: vfat
+    mountpoint: /boot
+    size: "50M"
+    type: part
+  - name: ${baseimg}2
+    fstype: swap
+    size: "32M"
+    type: part
+  - name: ${baseimg}3
+    fstype: ext4
+    mountpoint: /
+    size: "1.5G"
+    type: part
+
+bundles: [os-core, os-core-update, NetworkManager,  vim]
+
+autoUpdate: false
+postArchive: true
+postReboot: false
+telemetry: false
+iso: true
+keepImage: true
+CopySwupd: false
+
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native
+
+post-install: [
+   {cmd: "/bin/ls ${chrootDir}/etc"},
+   {chroot:true, cmd: "/bin/ls /etc"},
+]
+
+version: 0

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -97,6 +97,12 @@ func (tui *Tui) Run(md *model.SystemInstall, rootDir string, options args.Args) 
 	// configurations to the target system
 	tui.model.CopyNetwork = options.CopyNetwork
 
+	// When using the Interactive Installer we want to copy configurations
+	// from /etc/swupd by default to the target system
+	if !options.CopySwupdSet {
+		tui.model.CopySwupd = true
+	}
+
 	clui.SetThemePath(themeDir)
 
 	if !clui.SetCurrentTheme("clr-installer") {


### PR DESCRIPTION
Fixes Issue: #600

Changes proposed in this pull request:
- Copy swupd configuration files by default for interactive installs or if set in the YAML configuration file, or via a command-line option.
- Will not copy host /etc/swupd files by default when generating image files.


