### PR TITLE
Ensure locale always has a default

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -346,6 +346,11 @@ func lookupDir(dir, env string) (string, error) {
 // Locale is used to access the localization functions
 var Locale *gotext.Locale
 
+// Ensure Locale always has a default
+func init() {
+	SetLocale("en_US.UTF-8")
+}
+
 // SetLocale sets the locale of the installer based on the selected language
 func SetLocale(language string) {
 	dir, err := LookupLocaleDir()


### PR DESCRIPTION
Fixes Issue: #634

Changes proposed in this pull request:
- Initialize the locale structure to default (English) to ensure all translation calls result in a valid string

