### PR TITLE
ISO: Add metadata to ISO images

### DIFF
--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Intel Corporation
+// Copyright © 2020 Intel Corporation
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -56,6 +56,9 @@ func TestLoadFile(t *testing.T) {
 		{"valid-network.yaml", true},
 		{"valid-with-pre-post-hooks.yaml", true},
 		{"valid-with-version.yaml", true},
+		{"iso-bad.yaml", false},
+		{"iso-good.yaml", true},
+		{"iso-desktop.yaml", true},
 		{"azure-config.json", true},
 		{"azure-docker-config.json", true},
 		{"azure-machine-learning-config.json", true},
@@ -376,6 +379,55 @@ func TestAddNetworkInterface(t *testing.T) {
 	nm.AddNetworkInterface(loaded.NetworkInterfaces[0])
 	if len(nm.NetworkInterfaces) != 1 {
 		t.Fatal("Failed to add network interface to model")
+	}
+}
+
+func TestDesktopISOType(t *testing.T) {
+	path := filepath.Join(testsDir, "iso-desktop.yaml")
+	loaded, err := LoadFile(path, args.Args{})
+
+	loaded.AddUserBundle("user-basic")
+	loaded.AddUserBundle("python3-basic")
+
+	if err != nil {
+		t.Fatal("Failed to load a valid descriptor")
+	}
+
+	if !loaded.IsDesktopInstall() {
+		t.Fatal("Failed to detect Desktop ISO install from model")
+	}
+}
+
+func TestDesktopUserISOType(t *testing.T) {
+	path := filepath.Join(testsDir, "iso-good.yaml")
+	loaded, err := LoadFile(path, args.Args{})
+
+	loaded.AddUserBundle("user-basic")
+	loaded.AddUserBundle("python3-basic")
+	loaded.AddUserBundle("desktop-apps")
+
+	if err != nil {
+		t.Fatal("Failed to load a valid descriptor")
+	}
+
+	if !loaded.IsDesktopInstall() {
+		t.Fatal("Failed to detect Desktop ISO install from model")
+	}
+}
+
+func TestServerISOType(t *testing.T) {
+	path := filepath.Join(testsDir, "iso-good.yaml")
+	loaded, err := LoadFile(path, args.Args{})
+
+	loaded.AddUserBundle("user-basic")
+	loaded.AddUserBundle("python3-basic")
+
+	if err != nil {
+		t.Fatal("Failed to load a valid descriptor")
+	}
+
+	if loaded.IsDesktopInstall() {
+		t.Fatal("Detected Desktop ISO install, but should be Server from model")
 	}
 }
 

--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -133,6 +133,8 @@ Item | Description | Default
 `legacyBios` | Is the install using the Legacy boot from BIOS?; true or false | false
 `copyNetwork` | Copy the locally configured network interfaces to target; `/etc/systemd/network` | false
 `iso` | Generate a bootable ISO image file?; true or false | false
+`isoPublisher` | Publisher string added to ISO metadata; 128 char max | `-UNDEFINED-`
+`isoApplicationId` | Publisher string added to ISO metadata; 128 char max | server|desktop determined by bundle list
 `keepImage` | Retain the raw image file?; true or false | true (false when iso is true)
 `telemetry` | Should telemetry be enabled by default; true or false | false
 `telemetryURL` | URL of where the telemetry records should publish | `-UNDEFINED-`

--- a/tests/iso-bad.yaml
+++ b/tests/iso-bad.yaml
@@ -1,0 +1,56 @@
+#clear-linux-config
+
+# c-basic-offset: 2; tab-width: 2; indent-tabs-mode: nil
+# vi: set shiftwidth=2 tabstop=2 expandtab:
+# :indentSize=2:tabSize=2:noTabs=true:
+
+# File:         iso-bad.yaml
+# Use Case:     Basic functionality testing for an ISO.
+
+# switch between aliases if you want to install to an actual block device
+# i.e /dev/sda
+block-devices: [
+   {name: "image-gen", file: "image-gen.img"}
+]
+
+targetMedia:
+- name: ${baseimg}
+  type: disk
+  children:
+  - name: ${baseimg}1
+    fstype: vfat
+    mountpoint: /boot
+    size: "50M"
+    type: part
+  - name: ${baseimg}2
+    fstype: swap
+    size: "32M"
+    type: part
+  - name: ${baseimg}3
+    fstype: ext4
+    mountpoint: /
+    size: "1.5G"
+    type: part
+
+bundles: [os-core, os-core-update, NetworkManager,  vim]
+
+autoUpdate: false
+postArchive: true
+postReboot: false
+telemetry: false
+iso: true
+isoPublisher: 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+isoApplicationId: 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+keepImage: true
+copySwupd: false
+
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native
+
+post-install: [
+   {cmd: "/bin/ls ${chrootDir}/etc"},
+   {chroot:true, cmd: "/bin/ls /etc"},
+]
+
+version: 0

--- a/tests/iso-desktop.yaml
+++ b/tests/iso-desktop.yaml
@@ -1,0 +1,55 @@
+#clear-linux-config
+
+# c-basic-offset: 2; tab-width: 2; indent-tabs-mode: nil
+# vi: set shiftwidth=2 tabstop=2 expandtab:
+# :indentSize=2:tabSize=2:noTabs=true:
+
+# File:         iso-good.yaml
+# Use Case:     Basic functionality testing for a bad ISO.
+
+# switch between aliases if you want to install to an actual block device
+# i.e /dev/sda
+block-devices: [
+   {name: "image-gen", file: "image-gen.img"}
+]
+
+targetMedia:
+- name: ${baseimg}
+  type: disk
+  children:
+  - name: ${baseimg}1
+    fstype: vfat
+    mountpoint: /boot
+    size: "50M"
+    type: part
+  - name: ${baseimg}2
+    fstype: swap
+    size: "32M"
+    type: part
+  - name: ${baseimg}3
+    fstype: ext4
+    mountpoint: /
+    size: "1.5G"
+    type: part
+
+bundles: [os-core, os-core-update, desktop, NetworkManager,  vim]
+
+autoUpdate: false
+postArchive: true
+postReboot: false
+telemetry: false
+iso: true
+isoPublisher: Intel Corporation
+keepImage: true
+copySwupd: false
+
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native
+
+post-install: [
+   {cmd: "/bin/ls ${chrootDir}/etc"},
+   {chroot:true, cmd: "/bin/ls /etc"},
+]
+
+version: 0

--- a/tests/iso-good.yaml
+++ b/tests/iso-good.yaml
@@ -1,0 +1,56 @@
+#clear-linux-config
+
+# c-basic-offset: 2; tab-width: 2; indent-tabs-mode: nil
+# vi: set shiftwidth=2 tabstop=2 expandtab:
+# :indentSize=2:tabSize=2:noTabs=true:
+
+# File:         iso-good.yaml
+# Use Case:     Basic functionality testing for a bad ISO.
+
+# switch between aliases if you want to install to an actual block device
+# i.e /dev/sda
+block-devices: [
+   {name: "image-gen", file: "image-gen.img"}
+]
+
+targetMedia:
+- name: ${baseimg}
+  type: disk
+  children:
+  - name: ${baseimg}1
+    fstype: vfat
+    mountpoint: /boot
+    size: "50M"
+    type: part
+  - name: ${baseimg}2
+    fstype: swap
+    size: "32M"
+    type: part
+  - name: ${baseimg}3
+    fstype: ext4
+    mountpoint: /
+    size: "1.5G"
+    type: part
+
+bundles: [os-core, os-core-update, NetworkManager,  vim]
+
+autoUpdate: false
+postArchive: true
+postReboot: false
+telemetry: false
+iso: true
+isoPublisher: Intel Corporation
+isoApplicationId: good
+keepImage: true
+copySwupd: false
+
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-native
+
+post-install: [
+   {cmd: "/bin/ls ${chrootDir}/etc"},
+   {chroot:true, cmd: "/bin/ls /etc"},
+]
+
+version: 0


### PR DESCRIPTION
Changes proposed in this pull request:
- Add the publisher and the application/image type to the ISO.

```
$ iso-info live-server.iso
iso-info version 2.1.0 x86_64-generic-linux-gnu
Copyright (c) 2003-2005, 2007-2008, 2011-2015, 2017 R. Bernstein
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
__________________________________
ISO 9660 image: live-server.iso
Application : SERVER
Preparer    : XORRISO-1.5.2 2019.10.26.180001, LIBISOBURN-1.5.2, LIBISOFS-1.5.2, LIBBURN-1.5.2
Publisher   : INTEL CORPORATION
Volume      : CLR_ISO
No Joliet extensions

$ iso-info live-desktop.iso
iso-info version 2.1.0 x86_64-generic-linux-gnu
Copyright (c) 2003-2005, 2007-2008, 2011-2015, 2017 R. Bernstein
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
__________________________________
ISO 9660 image: live-desktop.iso
Application : DESKTOP
Preparer    : XORRISO-1.5.2 2019.10.26.180001, LIBISOBURN-1.5.2, LIBISOFS-1.5.2, LIBBURN-1.5.2
Publisher   : INTEL CORPORATION
Volume      : CLR_ISO
No Joliet extensions

```