### PR TITLE
 Additional Bundles Network fix

### DIFF
--- a/gui/network/network.go
+++ b/gui/network/network.go
@@ -1,4 +1,8 @@
-package gui
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package network
 
 import (
 	"strings"
@@ -24,6 +28,14 @@ type networkTestDialog struct {
 	pbar          *gtk.ProgressBar
 }
 
+type NetTestReturnCode int
+
+const (
+	NetTestSuccess NetTestReturnCode = 0
+	NetTestFailure NetTestReturnCode = 1
+	NetTestErr     NetTestReturnCode = 2
+)
+
 // createNetworkTestDialog creates a pop-up window for the network test
 func createNetworkTestDialog() (*networkTestDialog, error) {
 	var err error
@@ -32,12 +44,12 @@ func createNetworkTestDialog() (*networkTestDialog, error) {
 
 	// Create box
 	netDialog.box, err = gtk.BoxNew(gtk.ORIENTATION_VERTICAL, 0)
-	netDialog.box.SetHAlign(gtk.ALIGN_FILL)
-	netDialog.box.SetMarginBottom(common.TopBottomMargin)
 	if err != nil {
 		log.Error("Error creating box", err)
 		return nil, err
 	}
+	netDialog.box.SetHAlign(gtk.ALIGN_FILL)
+	netDialog.box.SetMarginBottom(common.TopBottomMargin)
 
 	// Create progress bar
 	netDialog.pbar, err = gtk.ProgressBarNew()
@@ -95,10 +107,10 @@ func createNetworkTestDialog() (*networkTestDialog, error) {
 }
 
 // RunNetworkTest creates pop-up window that runs a network check
-func RunNetworkTest(md *model.SystemInstall) error {
+func RunNetworkTest(md *model.SystemInstall) (NetTestReturnCode, error) {
 	netDialog, err := createNetworkTestDialog()
 	if err != nil {
-		return err
+		return NetTestErr, err
 	}
 
 	go func() {
@@ -121,7 +133,12 @@ func RunNetworkTest(md *model.SystemInstall) error {
 	}()
 	netDialog.dialog.Run()
 
-	return nil
+	if controller.NetworkPassing {
+		return NetTestSuccess, nil
+	}
+
+	return NetTestFailure, nil
+
 }
 
 // Desc will push a description box into the view for later marking

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -796,3 +796,10 @@ msgstr "Encrypted"
 
 msgid "Allow installation over insecure connections (http://)"
 msgstr "Allow installation over insecure connections (http://)"
+
+#, c-format
+msgid "This requires a working network connection.\nProceed with a network test?"
+msgstr "This requires a working network connection.\nProceed with a network test?"
+
+msgid "Network Required"
+msgstr "Network Required"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -794,5 +794,12 @@ msgstr "Utilice la partición existente."
 msgid "Encrypted"
 msgstr "Encriptado"
 
+#, c-format
 msgid "Allow installation over insecure connections (http://)"
 msgstr "Permitir la instalación a través de conexiones inseguras (http://)"
+
+msgid "This requires a working network connection.\nProceed with a network test?"
+msgstr "Esto requiere una conexión de red que funcione.\n¿Continuar con una prueba de red?"
+
+msgid "Network Required"
+msgstr "Red requerida"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -796,3 +796,10 @@ msgstr "加密"
 
 msgid "Allow installation over insecure connections (http://)"
 msgstr "允许在不安全的连接（http://）上安装"
+
+#, c-format
+msgid "This requires a working network connection.\nProceed with a network test?"
+msgstr "这需要有效的网络连接\n进行网络测试"
+
+msgid "Network Required"
+msgstr "需要网络"

--- a/tui/confirm_cancel.go
+++ b/tui/confirm_cancel.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Intel Corporation
+// Copyright © 2020 Intel Corporation
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -45,9 +45,8 @@ func (dialog *ConfirmCancelDialog) Close() {
 	}
 }
 
-func initCancelDiaglogWindow(dialog *ConfirmCancelDialog) error {
+func initCancelDiaglogWindow(dialog *ConfirmCancelDialog, title string) error {
 
-	const title = "Discard Data Changes?"
 	const wBuff = 5
 	const hBuff = 5
 	const dWidth = 50
@@ -91,11 +90,11 @@ func initCancelDiaglogWindow(dialog *ConfirmCancelDialog) error {
 	buttonFrame := clui.CreateFrame(borderFrame, AutoSize, 1, clui.BorderNone, clui.Fixed)
 	buttonFrame.SetPack(clui.Horizontal)
 	buttonFrame.SetGaps(1, 0)
-	dialog.cancelButton = CreateSimpleButton(buttonFrame, AutoSize, AutoSize, "No", Fixed)
+	dialog.cancelButton = CreateSimpleButton(buttonFrame, AutoSize, AutoSize, "Cancel", Fixed)
 	dialog.cancelButton.SetEnabled(true)
 	dialog.cancelButton.SetActive(true)
 
-	dialog.confirmButton = CreateSimpleButton(buttonFrame, AutoSize, AutoSize, "Yes", Fixed)
+	dialog.confirmButton = CreateSimpleButton(buttonFrame, AutoSize, AutoSize, "Confirm", Fixed)
 	dialog.confirmButton.SetEnabled(true)
 	dialog.confirmButton.SetActive(false)
 
@@ -103,7 +102,7 @@ func initCancelDiaglogWindow(dialog *ConfirmCancelDialog) error {
 }
 
 // CreateConfirmCancelDialogBox creates the Network PopUp
-func CreateConfirmCancelDialogBox(message string) (*ConfirmCancelDialog, error) {
+func CreateConfirmCancelDialogBox(message string, title string) (*ConfirmCancelDialog, error) {
 	dialog := new(ConfirmCancelDialog)
 
 	if dialog == nil {
@@ -115,7 +114,7 @@ func CreateConfirmCancelDialogBox(message string) (*ConfirmCancelDialog, error) 
 		dialog.message = "Data has changed and will be lost!\n\nDiscard data changes?"
 	}
 
-	if err := initCancelDiaglogWindow(dialog); err != nil {
+	if err := initCancelDiaglogWindow(dialog, title); err != nil {
 		return nil, fmt.Errorf("Failed to create Confirmation of Cancel Dialog: %v", err)
 	}
 

--- a/tui/user_manager.go
+++ b/tui/user_manager.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Intel Corporation
+// Copyright © 2020 Intel Corporation
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -327,7 +327,8 @@ func newUserManagerPage(tui *Tui) (Page, error) {
 	page.cancelBtn.OnClick(func(ev clui.Event) {
 		if page.usersChanged {
 			message := "User data modified and will be lost!\n\nDiscard user changes?"
-			if dialog, err := CreateConfirmCancelDialogBox(message); err == nil {
+			title := "Discard Data Changes?"
+			if dialog, err := CreateConfirmCancelDialogBox(message, title); err == nil {
 				dialog.OnClose(func() {
 					if dialog.Confirmed {
 						page.data = nil
@@ -359,7 +360,8 @@ func newUserManagerPage(tui *Tui) (Page, error) {
 	revertBtn.OnClick(func(ev clui.Event) {
 		if page.usersChanged {
 			message := "User data modified and will be lost!\n\nDiscard user changes?"
-			if dialog, err := CreateConfirmCancelDialogBox(message); err == nil {
+			title := "Discard Data Changes?"
+			if dialog, err := CreateConfirmCancelDialogBox(message, title); err == nil {
 				dialog.OnClose(func() {
 					if dialog.Confirmed {
 						page.removeAllUsers()


### PR DESCRIPTION
Fixes Issue: #635 

Changes proposed in this pull request:

- The user used to mistakenly click on items in the additional bundles
   page having to wait long duration necessarily if the network did not work.
  This provides the user with a warning saying that selecting an additional
   bundle requires a working internet connection


