### PR TITLE
args: add --cbm-path

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -93,6 +93,7 @@ type Args struct {
 	CopySwupd               bool
 	CopySwupdSet            bool
 	HighContrast            bool
+	CBMPath                 string
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -381,6 +382,15 @@ func (args *Args) setCommandLineArgs() (err error) {
 	flag.BoolVar(
 		&args.HighContrast, "high-contrast", false, "Use high-contrast colors for text-based UI",
 	)
+
+	flag.StringVarP(
+		&args.CBMPath, "cbm-path", "", "", "Path to clr-boot-manager (default: the target systems /usr/bin/clr-boot-manager)",
+	)
+	// We do not want this flag to be shown as part of the standard help message
+	fflag = flag.Lookup("cbm-path")
+	if fflag != nil {
+		fflag.Hidden = true
+	}
 
 	spflag.ErrHelp = errors.New("Clear Linux Installer program")
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -624,8 +624,14 @@ func contentInstall(rootDir string, version string, md *model.SystemInstall, opt
 	msg = utils.Locale.Get("Installing boot loader")
 	prg = progress.NewLoop(msg)
 	log.Info(msg)
+
+	cbmPath := options.CBMPath
+	if cbmPath == "" {
+		cbmPath = fmt.Sprintf("%s/usr/bin/clr-boot-manager", rootDir)
+	}
+
 	args := []string{
-		fmt.Sprintf("%s/usr/bin/clr-boot-manager", rootDir),
+		cbmPath,
 		"update",
 		"--image",
 		fmt.Sprintf("--path=%s", rootDir),


### PR DESCRIPTION
With the new flag we can easily instruct clr-installer to use an arbitrary
build/install, this flag eases the clr-boot-manager's CI by testing image generation
before we land new features.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>
