### PR TITLE
bundles: EOL python2 which has been deprecated

### DIFF
--- a/etc/bundles.json
+++ b/etc/bundles.json
@@ -69,10 +69,6 @@
       "desc": "Multi-protocol instant messagging (IM) client"
     },
     {
-      "name": "python2-basic",
-      "desc": "Run legacy python language programs"
-    },
-    {
       "name": "python3-basic",
       "desc": "Run python language programs"
     },

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -486,9 +486,6 @@ msgstr "Run perl language programs"
 msgid "Multi-protocol instant messagging (IM) client"
 msgstr "Multi-protocol instant messagging (IM) client"
 
-msgid "Run legacy python language programs"
-msgstr "Run legacy python language programs"
-
 msgid "Run python language programs"
 msgstr "Run python language programs"
 

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -486,9 +486,6 @@ msgstr "Ejecución de programas de lenguaje perl"
 msgid "Multi-protocol instant messagging (IM) client"
 msgstr "Cliente de mensajes instantáneos (IM) multiprotocolo"
 
-msgid "Run legacy python language programs"
-msgstr "Ejecución de programas heredados de lenguaje python"
-
 msgid "Run python language programs"
 msgstr "Ejecución de programas de lenguaje python"
 

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -486,9 +486,6 @@ msgstr "运行 Perl 语言程序"
 msgid "Multi-protocol instant messagging (IM) client"
 msgstr "多协议即时消息 (IM) 客户端"
 
-msgid "Run legacy python language programs"
-msgstr "运行旧有的 Python 语言程序"
-
 msgid "Run python language programs"
 msgstr "运行 Python 语言程序"
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove the python2 bundle which is no longer valid for Clear Linux OS


