### PR TITLE
fall back to legacy bios when efi is not present

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -410,7 +410,7 @@ func execute(options args.Args) error {
 
 	// Run system check and exit
 	if options.SystemCheck {
-		return syscheck.RunSystemCheck(false)
+		return syscheck.RunSystemCheck(md, false)
 	}
 
 	installReboot := false

--- a/gui/window.go
+++ b/gui/window.go
@@ -297,7 +297,7 @@ func (window *Window) createWelcomePage() (*Window, error) {
 	window.ActivatePage(window.menu.welcomePage)
 
 	// Create syscheck pop-up when system check fails
-	if syscheckErr := syscheck.RunSystemCheck(true); syscheckErr != nil {
+	if syscheckErr := syscheck.RunSystemCheck(window.model, true); syscheckErr != nil {
 		_, err = glib.IdleAdd(func() {
 			displaySyscheckDialog(syscheckErr)
 		})

--- a/syscheck/syscheck.go
+++ b/syscheck/syscheck.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/clearlinux/clr-installer/log"
+	"github.com/clearlinux/clr-installer/model"
 	"github.com/clearlinux/clr-installer/utils"
 )
 
@@ -31,14 +32,14 @@ func getCPUFeature(feature string) error {
 
 func getEFIExist() error {
 	if _, err := os.Stat("/sys/firmware/efi"); os.IsNotExist(err) {
-		return errors.New(utils.Locale.Get("Failed to find EFI firmware"))
+		return errors.New(utils.Locale.Get("Failed to find EFI firmware, falling back to legacy bios"))
 	}
 
 	return nil
 }
 
 // RunSystemCheck checks compatibility for clear linux. (e.g. EFI firmware, CPU featureset)
-func RunSystemCheck(quiet bool) error {
+func RunSystemCheck(md *model.SystemInstall, quiet bool) error {
 	log.Info("Running system compatibility checks.")
 
 	//Check the following CPU features from /proc/cpuinfo
@@ -80,8 +81,7 @@ func RunSystemCheck(quiet bool) error {
 			fmt.Println(err)
 		}
 		log.ErrorError(err)
-
-		return err
+		md.LegacyBios = true
 	}
 
 	if !quiet {

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -169,7 +169,7 @@ func (tui *Tui) Run(md *model.SystemInstall, rootDir string, options args.Args) 
 	}()
 
 	// Run system check, if fail report error and exit
-	if retErr := syscheck.RunSystemCheck(true); retErr != nil {
+	if retErr := syscheck.RunSystemCheck(md, true); retErr != nil {
 		msg := "System failed to pass pre-install checks." + "\n" +
 			retErr.Error() + "\n\n" +
 			"The application will now exit."


### PR DESCRIPTION
If the target system is not a efi system set the model to legacy bios mode.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>