### PR TITLE
scripts: add extra image descriptors

### DIFF
--- a/scripts/legacy-kvm-ext4-boot.yaml
+++ b/scripts/legacy-kvm-ext4-boot.yaml
@@ -1,0 +1,47 @@
+#clear-linux-config
+
+# Switch between aliases if you want to install to an actual block device.
+# i.e /dev/sda
+block-devices: [
+   {name: "bdevice", file: "legacy-kvm-ext4-boot.img"}
+]
+
+targetMedia:
+- name: ${bdevice}
+  size: "8.54G"
+  type: disk
+  children:
+  - name: ${bdevice}1
+    fstype: ext4
+    mountpoint: /boot
+    size: "512M"
+    type: part
+  - name: ${bdevice}2
+    fstype: swap
+    size: "32M"
+    type: part
+  - name: ${bdevice}3
+    fstype: ext4
+    mountpoint: /
+    size: "8G"
+    type: part
+
+bundles: [
+    bootloader,
+    editors,
+    network-basic,
+    openssh-server,
+    os-core,
+    os-core-update,
+    sysadmin-basic,
+  ]
+
+autoUpdate: false
+postArchive: false
+postReboot: false
+telemetry: false
+legacyBios: true
+
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-kvm

--- a/scripts/legacy-kvm-vfat-boot.yaml
+++ b/scripts/legacy-kvm-vfat-boot.yaml
@@ -1,0 +1,47 @@
+#clear-linux-config
+
+# Switch between aliases if you want to install to an actual block device.
+# i.e /dev/sda
+block-devices: [
+   {name: "bdevice", file: "legacy-kvm-vfat-boot.img"}
+]
+
+targetMedia:
+- name: ${bdevice}
+  size: "8.54G"
+  type: disk
+  children:
+  - name: ${bdevice}1
+    fstype: vfat
+    mountpoint: /boot
+    size: "512M"
+    type: part
+  - name: ${bdevice}2
+    fstype: swap
+    size: "32M"
+    type: part
+  - name: ${bdevice}3
+    fstype: ext4
+    mountpoint: /
+    size: "8G"
+    type: part
+
+bundles: [
+    bootloader,
+    editors,
+    network-basic,
+    openssh-server,
+    os-core,
+    os-core-update,
+    sysadmin-basic,
+  ]
+
+autoUpdate: false
+postArchive: false
+postReboot: false
+telemetry: false
+legacyBios: true
+
+keyboard: us
+language: en_US.UTF-8
+kernel: kernel-kvm


### PR DESCRIPTION
These configurations are intended to two different cbm configurations with dedicated
boot partitions either vfat and ext4 formatted.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>