### PR TITLE
model, log : Clean test yaml files

### DIFF
--- a/log/log_test.go
+++ b/log/log_test.go
@@ -220,6 +220,10 @@ func TestLogTraceableError(t *testing.T) {
 }
 
 func TestFailSeek(t *testing.T) {
+	defer func() {
+		_ = os.Remove("archivefile")
+	}()
+
 	err := ArchiveLogFile("archivefile")
 	if err == nil {
 		t.Fatal("Should have failed, unseekable file")
@@ -227,6 +231,10 @@ func TestFailSeek(t *testing.T) {
 }
 
 func TestNoFileHandle(t *testing.T) {
+	defer func() {
+		_ = os.Remove("archivefile")
+	}()
+
 	prevHandle := filehandle
 	filehandle = nil
 	err := ArchiveLogFile("archivefile")

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -638,7 +638,10 @@ func TestBackupFile(t *testing.T) {
 
 	md2, err := JSONtoYAMLConfig(path)
 	if err == nil {
-		defer func() { _ = os.Remove(path) }()
+		defer func() {
+			_ = os.Remove(path)
+			_ = os.Remove(bf)
+		}()
 		path, err = md2.WriteYAMLConfig(path)
 	}
 


### PR DESCRIPTION

Changes proposed in this pull request:
- backupfile needed to removed as part of model_test.go tests/valid-ister-full-physical-{timestamp}.yaml
- log/archivefile needs to be removed as part of log_test.go
