### PR TITLE
Remove unused have_vmx check from initrd_init

### DIFF
--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -49,14 +49,6 @@ check_result() {
     echo_tty_kmsg "[${SUCCESS}  OK  ${NORMAL}] $msg"
 }
 
-have_vmx() {
-    local feature="vmx"
-    local desc="Virtualisation support"
-    local need="$desc ($feature)"
-    have_cpu_feature "$feature"
-    check_result "$?" "$need"
-}
-
 have_ssse3_cpu_feature () {
     local feature="ssse3"
     local desc="Supplemental Streaming SIMD Extensions 3"


### PR DESCRIPTION
Changes proposed in this pull request:
- This removes the `have_vmx`check from the initrd_init template. It originally came from the compatibility-check script for checking compatibility for containers but isn't used by clr-installer as far as I can tell.



