### PR TITLE
storage: Enable Advanced Media Partition for CLI

### DIFF
--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -41,7 +41,7 @@ Item | Description | Required?
 `name:` | Block-device alias and partition number or the physical partition name| Yes
 `type:` | Partition type should be `part` for a standard partition or `crypt` for encrypted partitions | Yes
 `fstype:` | Type of the partition can be one of: `swap`, or `ext2`, `ext3`, `ext4`, `xfs`, `f2fs`, `btrfs`, or `vfat` | Yes
-`size:` | Size of the partition. Set to `0` to use the remaining free space for this partition; there can only be one partition of size `0`.The suffixes `B` for bytes, `K` for kilobytes, `M` for megabytes, `G` for gigabytes, `T` for terabytes, or `P` for petabytes can be used. | Yes 
+`size:` | Size of the partition. Set to `0` to use the remaining free space for this partition; there can only be one partition of size `0`.The suffixes `B` for bytes, `K` for kilobytes, `M` for megabytes, `G` for gigabytes, `T` for terabytes, or `P` for petabytes can be used. | Yes
 `mountpoint:` | The file system path where the partition should be mounted. | No
 `options:` | Additional file system options to be used when creating the fs | No
 `label:` | Short string labeling the partition | No
@@ -70,6 +70,29 @@ targetMedia:
     size: "2.6G"
     type: part
 ```
+
+### Advanced Installation Media Targets
+
+To use Advance Partition Labels for a command line installation, `targetMedia`
+should  be left out of the YAML configuration file. Instead, Partition Labels
+are used in to tag and convey which partitions should be used for an advanced
+installation.
+
+Partition Label | Description | Required?
+------------ | ------------- | ------------- 
+`CLR_BOOT` | The /boot partition; must be vfat | Yes
+`CLR_SWAP` | A swap partition to use; can be more than one | Yes
+`CLR_ROOT` | The / root partition; must be ext[234], xfs, or f2fs due to clr-boot-manager requirement | Yes
+`CLR_MNT_<mount_point>` | Any additional partitions that should be included in the install like /srv, /home, ... | No
+
+#### NOTE:
+You may also add `_F` to the partition label to force the formatting.
+#### EXAMPLES:
+Partition Label | Description
+------------ | -------------
+`CLR_F_SWAP` | Label a partition to be used as swap, and have the installer run mkswap on the partition.
+`CLR_MNT_/home` | Label a partition to be mounted as `/home`.
+`CLR_F_MNT_/data` | Label a partition to be mounted as `/data`, and have the installer run mkfs on the partition.
 
 ## Clear Linux Bundles
 This is a list of the Clear Linux OS Bundles that should be installed during the installation of the OS on the target media.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -55,7 +55,8 @@ type BlockDevice struct {
 	Children        []*BlockDevice     // children devices/partitions
 	UserDefined     bool               // was this value set by user?
 	MakePartition   bool               // Do we need to make a new partition?
-	FormatPartition bool               // Do we need to format the partition
+	FormatPartition bool               // Do we need to format the partition?
+	LabeledAdvanced bool               // Does this partition have a valid Advanced Label?
 	Options         string             // arbitrary mkfs.* options
 	available       bool               // was it mounted the moment we loaded?
 	partition       uint64             // Assigned partition for media - can't set until after mkpart
@@ -401,6 +402,7 @@ func (bd *BlockDevice) Clone() *BlockDevice {
 		UserDefined:     bd.UserDefined,
 		MakePartition:   bd.MakePartition,
 		FormatPartition: bd.FormatPartition,
+		LabeledAdvanced: bd.LabeledAdvanced,
 		available:       bd.available,
 		partition:       bd.partition,
 		PartTable:       bd.PartTable,

--- a/tests/coverage-curr-status
+++ b/tests/coverage-curr-status
@@ -22,7 +22,7 @@ ok  	github.com/clearlinux/clr-installer/model	0.031s	coverage: 91.7% of stateme
 ok  	github.com/clearlinux/clr-installer/network	4.525s	coverage: 26.9% of statements
 ?   	github.com/clearlinux/clr-installer/progress	[no test files]
 ?   	github.com/clearlinux/clr-installer/proxy	[no test files]
-ok  	github.com/clearlinux/clr-installer/storage	0.091s	coverage: 26.9% of statements
+ok  	github.com/clearlinux/clr-installer/storage	0.091s	coverage: 25.0% of statements
 ok  	github.com/clearlinux/clr-installer/swupd	0.012s	coverage: 21.8% of statements
 ?   	github.com/clearlinux/clr-installer/syscheck	[no test files]
 ok  	github.com/clearlinux/clr-installer/telemetry	0.758s	coverage: 41.9% of statements


### PR DESCRIPTION
Fixes Issue: #628

Changes proposed in this pull request:
- Allow the use of the Advanced Media Partition labels with CLI if no targetMedia is found in the YAML file.

