### PR TITLE
storage: f2fs uses lower case l for labels

### DIFF
--- a/storage/ops.go
+++ b/storage/ops.go
@@ -1083,6 +1083,10 @@ func getMakeFsLabel(bd *BlockDevice) []string {
 			labelArg = "-n"
 		}
 
+		if bd.FsType == "f2fs" {
+			labelArg = "-l"
+		}
+
 		if len(bd.Label) > maxLen {
 			shortLabel := string(bd.Label[0:(maxLen - 1)])
 			log.Warning("Truncating file system label '%s' to %d character label '%s'",


### PR DESCRIPTION
Fixes Issue: #681

Changes proposed in this pull request:
- Set the label flag to `-l` for f2fs file systems

