### PR TITLE
log: Fix formatting issues in output log file

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -148,7 +148,7 @@ func RunAndProcessOutput(printPrefix string, output Output, args ...string) erro
 	var exe string
 	var cmdArgs []string
 
-	log.Debug("%s", strings.Join(args, " "))
+	log.Debug(strings.Join(args, " "))
 
 	exe = args[0]
 	cmdArgs = args[1:]

--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Intel Corporation
+// Copyright © 2020 Intel Corporation
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/clearlinux/clr-installer/conf"
 	"github.com/clearlinux/clr-installer/errors"
@@ -167,11 +168,17 @@ func LevelStr(level int) (string, error) {
 }
 
 func logTag(tag string, format string, a ...interface{}) {
-	f := fmt.Sprintf("[%s] %s\n", tag, format)
+	// If there are no variable to pass to the format,
+	// then we can escape any % signs.
+	if len(a) < 1 {
+		format = strings.ReplaceAll(format, "%", "%%")
+	}
+
+	f := "[" + tag + "] " + format + "\n"
 	output := fmt.Sprintf(f, a...)
 
 	if level >= LogLevelVerbose {
-		log.Printf(output)
+		log.Print(output)
 		return
 	}
 
@@ -184,10 +191,10 @@ func logTag(tag string, format string, a ...interface{}) {
 			}
 
 			repeat := fmt.Sprintf("[%s] [Previous line repeated %d time%s]\n", tag, lineCount, plural)
-			log.Printf(repeat)
+			log.Print(repeat)
 		}
 
-		log.Printf(output)
+		log.Print(output)
 
 		lineLast = output
 		lineCount = 0

--- a/storage/ops.go
+++ b/storage/ops.go
@@ -118,10 +118,10 @@ func (bd *BlockDevice) updatePartitionInfo() error {
 		if len(fields) == 2 {
 			if fields[0] == "LABEL" {
 				bd.Label = fields[1]
-				log.Debug("updatePartitionInfo: Updated %d LABEL: %s", devFile, bd.Label)
+				log.Debug("updatePartitionInfo: Updated %s LABEL: %s", devFile, bd.Label)
 			} else if fields[0] == "UUID" {
 				bd.UUID = fields[1]
-				log.Debug("updatePartitionInfo: Updated %d UUID: %s", devFile, bd.UUID)
+				log.Debug("updatePartitionInfo: Updated %s UUID: %s", devFile, bd.UUID)
 			}
 		} else {
 			log.Debug("updatePartitionInfo: Ignoring unknown line: %s", line)
@@ -488,7 +488,7 @@ func (bd *BlockDevice) WritePartitionTable(legacyBios bool, wholeDisk bool, dryR
 		retries := 3
 		for {
 			mkPartCmd := mkPart + " " + getStartEndMB(start, end)
-			log.Debug("WritePartitionTable: mkPartCmd: %s", mkPartCmd)
+			log.Debug("WritePartitionTable: mkPartCmd: " + mkPartCmd)
 
 			args := append(baseArgs, mkPartCmd)
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1406,5 +1406,5 @@ func (bd *BlockDevice) DiskSize() (uint64, error) {
 }
 
 func (bd *BlockDevice) logDetails() {
-	log.Debug(bd.Name, bd.FsType, bd.MountPoint, bd.Size, bd.Type)
+	log.Debug("%s: fsType=%s, mount=%s, size=%d, type=%s", bd.Name, bd.FsType, bd.MountPoint, bd.Size, bd.Type)
 }


### PR DESCRIPTION
Fixes several problems in the output of the log file.
- Escaping percent signs
- Wrong format for data type
- Unnecessary format strings

