### PR TITLE
Makefile go lint: Avoid skipping whole files instead of functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,8 +350,6 @@ lint-gocyclo: lint-core
 	--skip-dirs-use-default \
 	--disable-all \
 	--enable=gocyclo \
-	--skip-files clr-installer/main.go,controller/controller.go \
-	--skip-files model/model_ister.go \
 	./...
 
 PHONY += lint-gofmt

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -126,6 +126,7 @@ func main() {
 }
 
 // execute is called by main to begin execution of the installer
+// nolint: gocyclo
 func execute(options args.Args) error {
 	var err error
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -59,6 +59,7 @@ func sortMountPoint(bds []*storage.BlockDevice) []*storage.BlockDevice {
 
 // Install is the main install controller, this is the entry point for a full
 // installation
+// nolint: gocyclo
 func Install(rootDir string, model *model.SystemInstall, options args.Args) error {
 	var err error
 	var version string


### PR DESCRIPTION
Signed-off-by: Karthik Prabhu Vinod <karthik.prabhu.vinod@intel.com>

Changes proposed in this pull request:
- Avoid Skipping wholes files while running linters. Instead as a fallback & quick fix, lint the
function in question and come back and fix later.



