### PR TITLE
Create Swapfile instead of Swap Partition

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -98,6 +98,7 @@ type Args struct {
 	SkipValidationSizeSet   bool
 	SkipValidationAll       bool
 	SkipValidationAllSet    bool
+	SwapFileSize            string
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -418,6 +419,10 @@ func (args *Args) setCommandLineArgs() (err error) {
 	)
 	// We do not want this flag to be shown as part of the standard help message
 	makeFlagHidden(flag, "skip-validation-all")
+
+	flag.StringVar(
+		&args.SwapFileSize, "swap-file-size", args.SwapFileSize, "Size of the swapfile; <size>[B|K|M|G]",
+	)
 
 	spflag.ErrHelp = errors.New("Clear Linux Installer program")
 

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -268,6 +268,9 @@ func execute(options args.Args) error {
 	if options.AllowInsecureHTTPSet {
 		md.AllowInsecureHTTP = options.AllowInsecureHTTP
 	}
+	if options.SwapFileSize != "" {
+		md.SwapFileSize = options.SwapFileSize
+	}
 
 	// Command line overrides the configuration file
 	if options.MakeISOSet {

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -269,7 +269,8 @@ func execute(options args.Args) error {
 		md.AllowInsecureHTTP = options.AllowInsecureHTTP
 	}
 	if options.SwapFileSize != "" {
-		md.SwapFileSize = options.SwapFileSize
+		md.MediaOpts.SwapFileSize = options.SwapFileSize
+		md.MediaOpts.SwapFileSet = true
 	}
 
 	// Command line overrides the configuration file
@@ -291,10 +292,10 @@ func execute(options args.Args) error {
 	}
 
 	if options.SkipValidationSizeSet {
-		md.SkipValidationSize = options.SkipValidationSize
+		md.MediaOpts.SkipValidationSize = options.SkipValidationSize
 	}
 	if options.SkipValidationAllSet {
-		md.SkipValidationAll = options.SkipValidationAll
+		md.MediaOpts.SkipValidationAll = options.SkipValidationAll
 	}
 
 	if len(options.Bundles) > 0 {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -241,7 +241,7 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 			wholeDisk = val.WholeDisk
 		}
 		// based on the description given, write the partition table
-		if err = curr.WritePartitionTable(model.LegacyBios, wholeDisk, nil); err != nil {
+		if err = curr.WritePartitionTable(model.MediaOpts.LegacyBios, wholeDisk, nil); err != nil {
 			return err
 		}
 
@@ -402,11 +402,11 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		return err
 	}
 
-	if model.SwapFileSize != "" {
+	if model.MediaOpts.SwapFileSize != "" {
 		msg := utils.Locale.Get("Creating %s", storage.SwapfileName)
 		prg = progress.NewLoop(msg)
 		log.Info(msg)
-		if err = storage.CreateSwapFile(rootDir, model.SwapFileSize); err != nil {
+		if err = storage.CreateSwapFile(rootDir, model.MediaOpts.SwapFileSize); err != nil {
 			prg.Failure()
 			return err
 		}
@@ -679,7 +679,7 @@ func contentInstall(rootDir string, version string,
 		"CBM_DEBUG": "1",
 	}
 
-	if md.LegacyBios {
+	if md.MediaOpts.LegacyBios {
 		envVars["CBM_FORCE_LEGACY"] = "1"
 	}
 
@@ -995,7 +995,7 @@ func generateISO(rootDir string, md *model.SystemInstall, options args.Args) err
 	var err error
 	log.Info("Building ISO image")
 
-	if !md.LegacyBios {
+	if !md.MediaOpts.LegacyBios {
 		for _, alias := range md.StorageAlias {
 			if err = isoutils.MakeIso(rootDir, strings.TrimSuffix(alias.File,
 				filepath.Ext(alias.File)), md, options); err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -402,6 +402,17 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		return err
 	}
 
+	if model.SwapFileSize != "" {
+		msg := utils.Locale.Get("Creating %s", storage.SwapfileName)
+		prg = progress.NewLoop(msg)
+		log.Info(msg)
+		if err = storage.CreateSwapFile(rootDir, model.SwapFileSize); err != nil {
+			prg.Failure()
+			return err
+		}
+		prg.Success()
+	}
+
 	if err = configureTimezone(rootDir, model); err != nil {
 		// Just log the error, not setting the timezone is not reason to fail the install
 		log.Error("Error setting timezone: %v", err)

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Intel Corporation
+// Copyright © 2020 Intel Corporation
 //
 // SPDX-License-Identifier: GPL-3.0-only
 

--- a/gui/window.go
+++ b/gui/window.go
@@ -194,7 +194,7 @@ func NewWindow(model *model.SystemInstall, rootDir string, options args.Args) (*
 	// Check if we can boot EFI
 	if !utils.HostHasEFI() {
 		log.Warning("Failed to find EFI firmware, falling back to legacy BIOS for installation.")
-		model.LegacyBios = true
+		model.MediaOpts.LegacyBios = true
 	}
 
 	// Create welcome page
@@ -885,8 +885,8 @@ func (window *Window) confirmInstall() {
 		}
 	}
 
-	medias := storage.GetPlannedMediaChanges(window.model.InstallSelected,
-		window.model.TargetMedias, window.model.LegacyBios)
+	medias := storage.GetPlannedMediaChanges(window.model.InstallSelected, window.model.TargetMedias,
+		window.model.MediaOpts)
 	for _, media := range medias {
 		log.Debug("MediaChange: %s", media)
 		buffer.Insert(buffer.GetEndIter(), media+"\n")

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -829,3 +829,11 @@ msgstr "Passphrase is based on a dictionary word"
 
 msgid "Passphrase is based on a (reversed) dictionary word"
 msgstr "Passphrase is based on a (reversed) dictionary word"
+
+#, c-format
+msgid "Could not interrupt %s"
+msgstr "Could not interrupt %s"
+
+#, c-format
+msgid "Creating %s"
+msgstr "Creating %s"

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -829,3 +829,11 @@ msgstr "La frase de contraseña se basa en una palabra del diccionario"
 
 msgid "Passphrase is based on a (reversed) dictionary word"
 msgstr "La frase de contraseña se basa en una palabra del diccionario invertida"
+
+#, c-format
+msgid "Could not interrupt %s"
+msgstr "No se ha podido interrumpir %s"
+
+#, c-format
+msgid "Creating %s"
+msgstr "Crear %s"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -829,3 +829,11 @@ msgstr "密码短语基于字典中的单词"
 
 msgid "Passphrase is based on a (reversed) dictionary word"
 msgstr "密码短语基于反向词典词"
+
+#, c-format
+msgid "Could not interrupt %s"
+msgstr "无法中断 %s"
+
+#, c-format
+msgid "Creating %s"
+msgstr "创建 %s"

--- a/massinstall/massinstall.go
+++ b/massinstall/massinstall.go
@@ -133,14 +133,14 @@ func (mi *MassInstall) Run(md *model.SystemInstall, rootDir string, options args
 		// If the partitions are defined from the configuration file,
 		// assume the user knows what they are doing and ignore validation checks
 		if !options.SkipValidationSizeSet && !options.SkipValidationAllSet {
-			md.SkipValidationSize = true
-			md.SkipValidationAll = true
+			md.MediaOpts.SkipValidationSize = true
+			md.MediaOpts.SkipValidationAll = true
 		} else {
 			if !options.SkipValidationSizeSet {
-				md.SkipValidationSize = true
+				md.MediaOpts.SkipValidationSize = true
 			} else {
 				if !options.SkipValidationAllSet {
-					md.SkipValidationAll = false
+					md.MediaOpts.SkipValidationAll = false
 				}
 			}
 		}
@@ -153,12 +153,11 @@ func (mi *MassInstall) Run(md *model.SystemInstall, rootDir string, options args
 		}
 
 		if md.IsTargetDesktopInstall() {
-			results = storage.DesktopValidatePartitions(md.TargetMedias, md.LegacyBios,
-				md.SkipValidationSize, md.SkipValidationAll)
+			results = storage.DesktopValidatePartitions(md.TargetMedias, md.MediaOpts)
 		} else {
-			results = storage.ServerValidatePartitions(md.TargetMedias, md.LegacyBios,
-				md.SkipValidationSize, md.SkipValidationAll)
+			results = storage.ServerValidatePartitions(md.TargetMedias, md.MediaOpts)
 		}
+
 		if len(results) > 0 {
 			for _, errStr := range results {
 				log.Error("Disk Partition: Validation Error: %q", errStr)
@@ -194,11 +193,9 @@ func (mi *MassInstall) Run(md *model.SystemInstall, rootDir string, options args
 			log.Debug("Mass installer operating in Advanced Disk Partition Mode.")
 			var results []string
 			if md.IsTargetDesktopInstall() {
-				results = storage.DesktopValidateAdvancedPartitions(devs, md.LegacyBios,
-					md.SkipValidationSize, md.SkipValidationAll)
+				results = storage.DesktopValidateAdvancedPartitions(devs, md.MediaOpts)
 			} else {
-				results = storage.ServerValidateAdvancedPartitions(devs, md.LegacyBios,
-					md.SkipValidationSize, md.SkipValidationAll)
+				results = storage.ServerValidateAdvancedPartitions(devs, md.MediaOpts)
 			}
 			if len(results) > 0 {
 				for _, errStr := range results {

--- a/model/model.go
+++ b/model/model.go
@@ -49,52 +49,49 @@ var testAlias = []string{}
 // SystemInstall represents the system install "configuration", the target
 // medias, bundles to install and whatever state a install may require
 type SystemInstall struct {
-	InstallSelected    map[string]storage.InstallTarget `yaml:"-"`
-	TargetMedias       []*storage.BlockDevice           `yaml:"targetMedia"`
-	NetworkInterfaces  []*network.Interface             `yaml:"networkInterfaces,omitempty,flow"`
-	Keyboard           *keyboard.Keymap                 `yaml:"keyboard,omitempty,flow"`
-	Language           *language.Language               `yaml:"language,omitempty,flow"`
-	Bundles            []string                         `yaml:"bundles,omitempty,flow"`
-	TargetBundles      []string                         `yaml:"targetBundles,omitempty,flow"`
-	UserBundles        []string                         `yaml:"userBundles,omitempty,flow"`
-	Offline            bool                             `yaml:"offline,omitempty,flow"`
-	HTTPSProxy         string                           `yaml:"httpsProxy,omitempty,flow"`
-	Telemetry          *telemetry.Telemetry             `yaml:"telemetry,omitempty,flow"`
-	Timezone           *timezone.TimeZone               `yaml:"timezone,omitempty,flow"`
-	Users              []*user.User                     `yaml:"users,omitempty,flow"`
-	KernelArguments    *kernel.Arguments                `yaml:"kernel-arguments,omitempty,flow"`
-	Kernel             *kernel.Kernel                   `yaml:"kernel,omitempty,flow"`
-	PostReboot         bool                             `yaml:"postReboot,omitempty,flow"`
-	SwupdMirror        string                           `yaml:"swupdMirror,omitempty,flow"`
-	AllowInsecureHTTP  bool                             `yaml:"AllowInsecureHTTP,omitempty,flow"`
-	SwupdSkipOptional  bool                             `yaml:"swupdSkipOptional,omitempty,flow"`
-	PostArchive        bool                             `yaml:"postArchive,omitempty,flow"`
-	Hostname           string                           `yaml:"hostname,omitempty,flow"`
-	AutoUpdate         bool                             `yaml:"autoUpdate,flow"`
-	TelemetryURL       string                           `yaml:"telemetryURL,omitempty,flow"`
-	TelemetryTID       string                           `yaml:"telemetryTID,omitempty,flow"`
-	TelemetryPolicy    string                           `yaml:"telemetryPolicy,omitempty,flow"`
-	PreInstall         []*InstallHook                   `yaml:"pre-install,omitempty,flow"`
-	PostInstall        []*InstallHook                   `yaml:"post-install,omitempty,flow"`
-	PostImage          []*InstallHook                   `yaml:"post-image,omitempty,flow"`
-	SwupdFormat        string                           `yaml:"swupdFormat,omitempty,flow"`
-	Version            uint                             `yaml:"version,omitempty,flow"`
-	StorageAlias       []*StorageAlias                  `yaml:"block-devices,omitempty,flow"`
-	LegacyBios         bool                             `yaml:"legacyBios,omitempty,flow"`
-	CopyNetwork        bool                             `yaml:"copyNetwork,omitempty,flow"`
-	CopySwupd          bool                             `yaml:"copySwupd,omitempty,flow"`
-	Environment        map[string]string                `yaml:"env,omitempty,flow"`
-	CryptPass          string                           `yaml:"-"`
-	MakeISO            bool                             `yaml:"iso,omitempty,flow"`
-	ISOPublisher       string                           `yaml:"isoPublisher,omitempty,flow"`
-	ISOApplicationID   string                           `yaml:"isoApplicationId,omitempty,flow"`
-	KeepImage          bool                             `yaml:"keepImage,omitempty,flow"`
-	LockFile           string                           `yaml:"-"`
-	ClearCfFile        string                           `yaml:"-"`
-	PreCheckDone       bool                             `yaml:"preCheckDone,omitempty,flow"`
-	SkipValidationSize bool                             `yaml:"skipValidationSize,omitempty,flow"`
-	SkipValidationAll  bool                             `yaml:"skipValidationAll,omitempty,flow"`
-	SwapFileSize       string                           `yaml:"swapFileSize,omitempty,flow"`
+	InstallSelected   map[string]storage.InstallTarget `yaml:"-"`
+	TargetMedias      []*storage.BlockDevice           `yaml:"targetMedia"`
+	NetworkInterfaces []*network.Interface             `yaml:"networkInterfaces,omitempty,flow"`
+	Keyboard          *keyboard.Keymap                 `yaml:"keyboard,omitempty,flow"`
+	Language          *language.Language               `yaml:"language,omitempty,flow"`
+	Bundles           []string                         `yaml:"bundles,omitempty,flow"`
+	TargetBundles     []string                         `yaml:"targetBundles,omitempty,flow"`
+	UserBundles       []string                         `yaml:"userBundles,omitempty,flow"`
+	Offline           bool                             `yaml:"offline,omitempty,flow"`
+	HTTPSProxy        string                           `yaml:"httpsProxy,omitempty,flow"`
+	Telemetry         *telemetry.Telemetry             `yaml:"telemetry,omitempty,flow"`
+	Timezone          *timezone.TimeZone               `yaml:"timezone,omitempty,flow"`
+	Users             []*user.User                     `yaml:"users,omitempty,flow"`
+	KernelArguments   *kernel.Arguments                `yaml:"kernel-arguments,omitempty,flow"`
+	Kernel            *kernel.Kernel                   `yaml:"kernel,omitempty,flow"`
+	PostReboot        bool                             `yaml:"postReboot,omitempty,flow"`
+	SwupdMirror       string                           `yaml:"swupdMirror,omitempty,flow"`
+	AllowInsecureHTTP bool                             `yaml:"AllowInsecureHTTP,omitempty,flow"`
+	SwupdSkipOptional bool                             `yaml:"swupdSkipOptional,omitempty,flow"`
+	PostArchive       bool                             `yaml:"postArchive,omitempty,flow"`
+	Hostname          string                           `yaml:"hostname,omitempty,flow"`
+	AutoUpdate        bool                             `yaml:"autoUpdate,flow"`
+	TelemetryURL      string                           `yaml:"telemetryURL,omitempty,flow"`
+	TelemetryTID      string                           `yaml:"telemetryTID,omitempty,flow"`
+	TelemetryPolicy   string                           `yaml:"telemetryPolicy,omitempty,flow"`
+	PreInstall        []*InstallHook                   `yaml:"pre-install,omitempty,flow"`
+	PostInstall       []*InstallHook                   `yaml:"post-install,omitempty,flow"`
+	PostImage         []*InstallHook                   `yaml:"post-image,omitempty,flow"`
+	SwupdFormat       string                           `yaml:"swupdFormat,omitempty,flow"`
+	Version           uint                             `yaml:"version,omitempty,flow"`
+	StorageAlias      []*StorageAlias                  `yaml:"block-devices,omitempty,flow"`
+	CopyNetwork       bool                             `yaml:"copyNetwork,omitempty,flow"`
+	CopySwupd         bool                             `yaml:"copySwupd,omitempty,flow"`
+	Environment       map[string]string                `yaml:"env,omitempty,flow"`
+	CryptPass         string                           `yaml:"-"`
+	MakeISO           bool                             `yaml:"iso,omitempty,flow"`
+	ISOPublisher      string                           `yaml:"isoPublisher,omitempty,flow"`
+	ISOApplicationID  string                           `yaml:"isoApplicationId,omitempty,flow"`
+	KeepImage         bool                             `yaml:"keepImage,omitempty,flow"`
+	LockFile          string                           `yaml:"-"`
+	ClearCfFile       string                           `yaml:"-"`
+	PreCheckDone      bool                             `yaml:"preCheckDone,omitempty,flow"`
+	MediaOpts         storage.MediaOpts                `yaml:",inline"`
 }
 
 // SystemUsage is used to include additional information into the telemetry payload
@@ -347,13 +344,11 @@ func (si *SystemInstall) Validate() error {
 
 	var results []string
 	if si.IsTargetDesktopInstall() {
-		results = storage.DesktopValidatePartitions(si.TargetMedias, si.LegacyBios,
-			si.SkipValidationSize, si.SkipValidationAll)
+		results = storage.DesktopValidatePartitions(si.TargetMedias, si.MediaOpts)
 	} else {
-		results = storage.ServerValidatePartitions(si.TargetMedias, si.LegacyBios,
-			si.SkipValidationSize, si.SkipValidationAll)
+		results = storage.ServerValidatePartitions(si.TargetMedias, si.MediaOpts)
 	}
-	if len(results) > 0 && !si.SkipValidationAll {
+	if len(results) > 0 && !si.MediaOpts.SkipValidationAll {
 		return errors.ValidationErrorf(strings.Join(results, ", "))
 	}
 
@@ -521,6 +516,10 @@ func LoadFile(path string, options args.Args) (*SystemInstall, error) {
 		}
 	}
 
+	if result.MediaOpts.SwapFileSize != "" {
+		result.MediaOpts.SwapFileSet = true
+	}
+
 	if result.Version > 0 {
 		result.AutoUpdate = false
 	}
@@ -605,8 +604,8 @@ func (si *SystemInstall) WriteFile(path string) error {
 	// SkipValidation flags are okay for ready, but we
 	// never want to store them -- force use to set them
 	// Setting to default means they are omitted
-	copyModel.SkipValidationAll = false
-	copyModel.SkipValidationSize = false
+	copyModel.MediaOpts.SkipValidationAll = false
+	copyModel.MediaOpts.SkipValidationSize = false
 
 	b, err := yaml.Marshal(copyModel)
 	if err != nil {
@@ -661,6 +660,9 @@ func (si *SystemInstall) WriteScrubModelTargetMedias() (string, error) {
 	// Remove the target media
 	cleanModel.TargetMedias = nil
 
+	// Remove the Media swapfile if set as we might return with a swap partition
+	cleanModel.MediaOpts.SwapFileSize = ""
+
 	tmpYaml, err := ioutil.TempFile("", "clr-installer-noMedia-*.yaml")
 	if err != nil {
 		return "", errors.Errorf("Could not make YAML tempfile: %v", err)
@@ -684,4 +686,20 @@ func (si *SystemInstall) InteractiveOptionsValid() error {
 	}
 
 	return nil
+}
+
+// SetDefaultSwapFileSize defines the swapfile sized based on
+// the storage default swapfile size
+func (si *SystemInstall) SetDefaultSwapFileSize() {
+	if si.MediaOpts.SwapFileSize == "" {
+		si.MediaOpts.SwapFileSize, _ = storage.HumanReadableSizeXiBWithPrecision(storage.SwapFileSizeDefault, 1)
+	}
+}
+
+// ResetDefaultSwapFileSize clears the swapfile size unless it
+// has been explicitly set by the YAML or command line
+func (si *SystemInstall) ResetDefaultSwapFileSize() {
+	if !si.MediaOpts.SwapFileSet {
+		si.MediaOpts.SwapFileSize = ""
+	}
 }

--- a/model/model.go
+++ b/model/model.go
@@ -94,6 +94,7 @@ type SystemInstall struct {
 	PreCheckDone       bool                             `yaml:"preCheckDone,omitempty,flow"`
 	SkipValidationSize bool                             `yaml:"skipValidationSize,omitempty,flow"`
 	SkipValidationAll  bool                             `yaml:"skipValidationAll,omitempty,flow"`
+	SwapFileSize       string                           `yaml:"swapFileSize,omitempty,flow"`
 }
 
 // SystemUsage is used to include additional information into the telemetry payload

--- a/model/model_ister.go
+++ b/model/model_ister.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Intel Corporation
+// Copyright © 2020 Intel Corporation
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -275,8 +275,8 @@ func JSONtoYAMLConfig(cf string) (*SystemInstall, error) {
 		si.PostInstall = append(si.PostInstall, &pi)
 	}
 
-	si.LegacyBios = ic.LegacyBios // Set LegacyBios
-	si.SwupdMirror = ic.MirrorURL // Set SwupdMirror
+	si.MediaOpts.LegacyBios = ic.LegacyBios // Set LegacyBios
+	si.SwupdMirror = ic.MirrorURL           // Set SwupdMirror
 
 	si.HTTPSProxy = ic.HTTPSProxy // Set HTTPSProxy
 	if si.HTTPSProxy == "" {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -120,8 +120,8 @@ func TestLoadFile(t *testing.T) {
 		}
 
 		if model != nil {
-			model.SkipValidationSize = true
-			model.SkipValidationAll = true
+			model.MediaOpts.SkipValidationSize = true
+			model.MediaOpts.SkipValidationAll = true
 		}
 		err = model.Validate()
 		if curr.valid && err != nil {
@@ -716,5 +716,37 @@ func TestInterActivePass(t *testing.T) {
 
 	if err := si.InteractiveOptionsValid(); err != nil {
 		t.Fatalf("Interactive should pass: %v", err)
+	}
+}
+
+func TestSetDefaultSwapFilePass(t *testing.T) {
+	si := &SystemInstall{}
+	if si.MediaOpts.SwapFileSize != "" {
+		t.Fatalf("Default SwapFileSize should be empty: %q", si.MediaOpts.SwapFileSize)
+	}
+
+	si.SetDefaultSwapFileSize()
+	if si.MediaOpts.SwapFileSize == "" {
+		t.Fatalf("SwapFileSize should be string version of %d", storage.SwapFileSizeDefault)
+	}
+
+	testValue := "invalid-but-legal"
+	si.MediaOpts.SwapFileSize = testValue
+	si.SetDefaultSwapFileSize()
+	if si.MediaOpts.SwapFileSize != testValue {
+		t.Fatalf("SwapFileSize should be string %q", testValue)
+	}
+
+	si.ResetDefaultSwapFileSize()
+	if si.MediaOpts.SwapFileSize != "" {
+		t.Fatalf("SwapFileSize should be clear to empty string, not %q", si.MediaOpts.SwapFileSize)
+	}
+
+	testValue = "4G"
+	si.MediaOpts.SwapFileSize = testValue
+	si.MediaOpts.SwapFileSet = true
+	si.ResetDefaultSwapFileSize()
+	if si.MediaOpts.SwapFileSize == "" {
+		t.Fatalf("SwapFileSize should be set to %q, but it is empty", testValue)
 	}
 }

--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -41,7 +41,7 @@ Item | Description | Required?
 `name:` | Block-device alias and partition number or the physical partition name| Yes
 `type:` | Partition type should be `part` for a standard partition or `crypt` for encrypted partitions | Yes
 `fstype:` | Type of the partition can be one of: `swap`, or `ext2`, `ext3`, `ext4`, `xfs`, `f2fs`, `btrfs`, or `vfat` | Yes
-`size:` | Size of the partition. Set to `0` to use the remaining free space for this partition; there can only be one partition of size `0`.The suffixes `B` for bytes, `K` for kilobytes, `M` for megabytes, `G` for gigabytes, `T` for terabytes, or `P` for petabytes can be used. | Yes
+`size:` | Size of the partition. Set to `0` to use the remaining free space for this partition; there can only be one partition of size `0`. The suffixes `B` for bytes, `K` or `KB` for kilobytes, `M` or `MB` for megabytes, `G` or `GB` for gigabytes, `T` or `TB` for terabytes, `P` or `PB` for petabytes, `KiB` for kibibyte, `MiB` for mebibyte, `GiB` for gibibyte, `TiB` for tebibyte, `PiB` for pebibyte can be used.  | Yes
 `mountpoint:` | The file system path where the partition should be mounted. | No
 `options:` | Additional file system options to be used when creating the fs | No
 `label:` | Short string labeling the partition | No
@@ -58,18 +58,23 @@ targetMedia:
   - name: ${installer}1
     fstype: vfat
     mountpoint: /boot
-    size: "150M"
+    size: "150MiB"
     type: part
   - name: ${installer}2
-    fstype: swap
-    size: "256M"
-    type: part
-  - name: ${installer}3
     fstype: ext4
     mountpoint: /
-    size: "2.6G"
+    size: "2.6GiB"
     type: part
 ```
+
+### Swap
+The default, as of release `2.5.0`, is to create a swapfile `/var/swapfile` during an interactive installation or if no swap partition is defined when Advanced Installation Media Targets are defined. The default swapfile size can be overridden by setting it in the YAML configuration file, which in turn can be overridden by using the `--swap-file-size=<size>` on the command line.
+
+```yaml
+swapFileSize: "64MiB"
+```
+
+If a swap partition is defined and the swapFileSize or `--swap-file-size=<size>` are set, both types of swap will be configured in the target system.
 
 ### Advanced Installation Media Targets
 
@@ -81,8 +86,8 @@ installation.
 Partition Label | Description | Required?
 ------------ | ------------- | ------------- 
 `CLR_BOOT` | The /boot partition; must be vfat | Yes
-`CLR_SWAP` | A swap partition to use; can be more than one | Yes
 `CLR_ROOT` | The / root partition; must be ext[234], xfs, or f2fs due to clr-boot-manager requirement | Yes
+`CLR_SWAP` | A optional swap partition; can be more than one or used in place of a swapfile | No
 `CLR_MNT_<mount_point>` | Any additional partitions that should be included in the install like /srv, /home, ... | No
 
 #### NOTE:
@@ -140,6 +145,7 @@ Item | Description | Default
 `keyboard:` | Name of the keyboard type. Valid value can be found using `localectl list-keymaps`; may require installing the `kbd` bundle first. | us
 `language:` | Name of the system language. Valid values can be found using `locale -a`; may require installing the `glibc-locale` bundle first. | en_US.UTF-8
 `timezone:` | Name of the system timezone. Valid values can be found using `timedatectl list-timezones`; may require installing the `tzdata` bundle first. | UTC
+`swapFileSize:` | Size of the swapfile. If set to `0` no swapfile will be created. The suffixes `B` for bytes, `K` or `KB` for kilobytes, `M` or `MB` for megabytes, `G` or `GB` for gigabytes, `KiB` for kibibyte, `MiB` for mebibyte, `GiB` for gibibyte. | `-UNDEFINED-`
 `kernel` | Kernel bundle to be used | kernel-native
 `httpsProxy` | HTTPS Proxy as a string | `-UNDEFINED-`
 `allowInsecureHttp` | Allow installation and downloads over insecure connections | false

--- a/storage/block_devices.go
+++ b/storage/block_devices.go
@@ -197,8 +197,8 @@ var (
 		"/dev/mmcblk": "p",
 	}
 
-	bootSize = uint64(150 * (1000 * 1000))
-	swapSize = uint64(256 * (1000 * 1000))
+	bootSizeDefault     = uint64(150 * (1024 * 1024))
+	SwapFileSizeDefault = uint64(64 * (1024 * 1024))
 )
 
 func getAliasSuffix(file string) string {
@@ -386,18 +386,6 @@ func (bd *BlockDevice) FsTypeNotSwap() bool {
 	return bd.FsType != "swap"
 }
 
-// DeviceHasSwap returns true if the block device has a swap partition
-func (bd *BlockDevice) DeviceHasSwap() bool {
-	hasSwap := false
-
-	for _, part := range bd.Children {
-		if part.FsType == "swap" {
-			hasSwap = true
-		}
-	}
-	return hasSwap
-}
-
 // RemoveChild removes a partition from disk block device
 func (bd *BlockDevice) RemoveChild(child *BlockDevice) {
 	copyBd := bd.Clone()
@@ -444,28 +432,28 @@ func (bd *BlockDevice) AddChild(child *BlockDevice) {
 	log.Debug("AddChild: child.Name is %q", child.Name)
 }
 
-// HumanReadableSizeWithUnitAndPrecision converts the size representation in bytes to the
-// closest human readable format i.e 10M, 1G, 2T etc with a forced unit and precision
-func (bd *BlockDevice) HumanReadableSizeWithUnitAndPrecision(unit string, precision int) (string, error) {
-	return HumanReadableSizeWithUnitAndPrecision(bd.Size, unit, precision)
+// HumanReadableSizeXiBWithUnitAndPrecision converts the size representation in bytes to the
+// closest human readable format i.e 10MiB, 1GiB, 2TiB etc with a forced unit and precision
+func (bd *BlockDevice) HumanReadableSizeXiBWithUnitAndPrecision(unit string, precision int) (string, error) {
+	return HumanReadableSizeXiBWithUnitAndPrecision(bd.Size, unit, precision)
 }
 
-// HumanReadableSizeWithPrecision converts the size representation in bytes to the
-// closest human readable format i.e 10M, 1G, 2T etc with a forced precision
-func (bd *BlockDevice) HumanReadableSizeWithPrecision(precision int) (string, error) {
-	return bd.HumanReadableSizeWithUnitAndPrecision("", precision)
+// HumanReadableSizeXiBWithPrecision converts the size representation in bytes to the
+// closest human readable format i.e 10MiB, 1GiB, 2TiB etc with a forced precision
+func (bd *BlockDevice) HumanReadableSizeXiBWithPrecision(precision int) (string, error) {
+	return bd.HumanReadableSizeXiBWithUnitAndPrecision("", precision)
 }
 
-// HumanReadableSizeWithUnit converts the size representation in bytes to the
-// closest human readable format i.e 10M, 1G, 2T etc with a forced unit
-func (bd *BlockDevice) HumanReadableSizeWithUnit(unit string) (string, error) {
-	return bd.HumanReadableSizeWithUnitAndPrecision(unit, -1)
+// HumanReadableSizeXiBWithUnit converts the size representation in bytes to the
+// closest human readable format i.e 10MiB, 1GiB, 2TiB etc with a forced unit
+func (bd *BlockDevice) HumanReadableSizeXiBWithUnit(unit string) (string, error) {
+	return bd.HumanReadableSizeXiBWithUnitAndPrecision(unit, -1)
 }
 
-// HumanReadableSize converts the size representation in bytes to the closest
-// human readable format i.e 10M, 1G, 2T etc
-func (bd *BlockDevice) HumanReadableSize() (string, error) {
-	return bd.HumanReadableSizeWithUnitAndPrecision("", -1)
+// HumanReadableSizeXiB converts the size representation in bytes to the closest
+// human readable format i.e 10MiB, 1GiB, 2TiB etc
+func (bd *BlockDevice) HumanReadableSizeXiB() (string, error) {
+	return bd.HumanReadableSizeXiBWithUnitAndPrecision("", -1)
 }
 
 // UpdateBlockDevices updates the Label and UUID information only

--- a/storage/parted_partition.go
+++ b/storage/parted_partition.go
@@ -33,9 +33,9 @@ func (part *PartedPartition) Clone() *PartedPartition {
 
 // AddBootStandardPartition will add to disk a new standard Boot partition
 func AddBootStandardPartition(disk *BlockDevice) uint64 {
-	freePart := disk.findFree(bootSize)
+	freePart := disk.findFree(bootSizeDefault)
 	disk.AddFromFreePartition(freePart, &BlockDevice{
-		Size:            bootSize,
+		Size:            bootSizeDefault,
 		Type:            BlockDeviceTypePart,
 		FsType:          "vfat",
 		MountPoint:      "/boot",
@@ -45,23 +45,7 @@ func AddBootStandardPartition(disk *BlockDevice) uint64 {
 		FormatPartition: true,
 	})
 
-	return bootSize
-}
-
-// AddSwapStandardPartition will add to disk a new standard Swap partition
-func AddSwapStandardPartition(disk *BlockDevice) uint64 {
-	freePart := disk.findFree(swapSize)
-	disk.AddFromFreePartition(freePart, &BlockDevice{
-		Size:            swapSize,
-		Type:            BlockDeviceTypePart,
-		FsType:          "swap",
-		Label:           "swap",
-		UserDefined:     true,
-		MakePartition:   true,
-		FormatPartition: true,
-	})
-
-	return swapSize
+	return bootSizeDefault
 }
 
 // AddRootStandardPartition will add to disk a new standard Root partition
@@ -93,26 +77,15 @@ func NewStandardPartitions(disk *BlockDevice) {
 	disk.PartTable = nil
 	disk.PartTable = append(disk.PartTable, newFreePart)
 
-	rootSize := uint64(disk.Size - bootSize - swapSize)
+	rootSize := uint64(disk.Size - bootSizeDefault)
 
-	freePart := disk.findFree(bootSize)
+	freePart := disk.findFree(bootSizeDefault)
 	disk.AddFromFreePartition(freePart, &BlockDevice{
-		Size:            bootSize,
+		Size:            bootSizeDefault,
 		Type:            BlockDeviceTypePart,
 		FsType:          "vfat",
 		MountPoint:      "/boot",
 		Label:           "boot",
-		UserDefined:     true,
-		MakePartition:   true,
-		FormatPartition: true,
-	})
-
-	freePart = disk.findFree(swapSize)
-	disk.AddFromFreePartition(freePart, &BlockDevice{
-		Size:            swapSize,
-		Type:            BlockDeviceTypePart,
-		FsType:          "swap",
-		Label:           "swap",
 		UserDefined:     true,
 		MakePartition:   true,
 		FormatPartition: true,

--- a/storage/swapfile.go
+++ b/storage/swapfile.go
@@ -1,0 +1,79 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package storage
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/clearlinux/clr-installer/cmd"
+	"github.com/clearlinux/clr-installer/errors"
+	"github.com/clearlinux/clr-installer/log"
+)
+
+const (
+	// SwapfileName is the default name of the swap file to create
+	SwapfileName = "/var/swapfile"
+)
+
+// CreateSwapFile is responsible for generating a valid swapfile
+// on the installation target
+func CreateSwapFile(rootDir string, sizeString string) error {
+
+	size, err := ParseVolumeSize(sizeString)
+	if err != nil {
+		return err
+	}
+
+	// size is in bytes, but we will only create swapfile in MB increments
+	swapFileSize := size / (1024 * 1024)
+
+	swapFile := filepath.Join(rootDir, SwapfileName)
+
+	if err := allocateSwapFile(swapFile, swapFileSize); err != nil {
+		return err
+	}
+	args := []string{
+		"mkswap",
+		swapFile,
+	}
+
+	if err := cmd.RunAndLog(args...); err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func allocateSwapFile(swapFile string, blockCount uint64) error {
+	// The block size is always in MB
+	block := make([]byte, 1024*1024)
+
+	// The permissions on the swap file should always be 0600
+	f, err := os.OpenFile(swapFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	// Write bytes to file
+	bytesWritten := 0
+
+	var i uint64
+	for i = 0; i < blockCount; i++ {
+		byteCount, err := f.Write(block)
+		if err != nil {
+			return err
+		}
+		bytesWritten += byteCount
+	}
+
+	log.Debug("allocateSwapFile: Wrote %d bytes.", bytesWritten)
+
+	return nil
+}

--- a/tui/confirm_install.go
+++ b/tui/confirm_install.go
@@ -136,8 +136,8 @@ func initConfirmDiaglogWindow(dialog *ConfirmInstallDialog) error {
 	dialog.mediaDetail.SetWordWrap(true)
 	dialog.mediaDetail.SetStyle("AltEdit")
 
-	medias := storage.GetPlannedMediaChanges(dialog.modelSI.InstallSelected,
-		dialog.modelSI.TargetMedias, dialog.modelSI.LegacyBios)
+	medias := storage.GetPlannedMediaChanges(dialog.modelSI.InstallSelected, dialog.modelSI.TargetMedias,
+		dialog.modelSI.MediaOpts)
 	for _, media := range medias {
 		log.Debug("MediaChange: %s", media)
 	}

--- a/tui/media_config.go
+++ b/tui/media_config.go
@@ -322,6 +322,8 @@ func (page *MediaConfigPage) safeRadioOnChange(active bool) {
 		log.Warning(warning)
 		warning = fmt.Sprintf("Warning: %s", warning)
 		page.labelWarning.SetTitle(warning)
+		page.labelWarning.SetBackColor(errorLabelBg)
+		page.labelWarning.SetTextColor(errorLabelFg)
 	}
 }
 
@@ -350,6 +352,8 @@ func (page *MediaConfigPage) destructiveRadioOnChange(active bool) {
 		log.Warning(warning)
 		warning = fmt.Sprintf("Warning: %s", warning)
 		page.labelWarning.SetTitle(warning)
+		page.labelWarning.SetBackColor(errorLabelBg)
+		page.labelWarning.SetTextColor(errorLabelFg)
 	} else {
 		page.labelDestructive.SetTitle(storage.DestructiveWarning)
 	}
@@ -384,6 +388,8 @@ func (page *MediaConfigPage) advancedRadioOnChange(active bool) {
 		log.Warning(warning)
 		warning = fmt.Sprintf("Warning: %s", warning)
 		page.labelWarning.SetTitle(warning)
+		page.labelWarning.SetBackColor(errorLabelBg)
+		page.labelWarning.SetTextColor(errorLabelFg)
 		page.advancedCfgBtn.SetEnabled(false)
 	} else {
 		si := page.getModel()

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -106,7 +106,7 @@ func (tui *Tui) Run(md *model.SystemInstall, rootDir string, options args.Args) 
 	// Check if we can boot EFI
 	if !utils.HostHasEFI() {
 		log.Warning("Failed to find EFI firmware, falling back to legacy BIOS for installation.")
-		tui.model.LegacyBios = true
+		tui.model.MediaOpts.LegacyBios = true
 	}
 
 	clui.SetThemePath(themeDir)


### PR DESCRIPTION
Fixes Issue: #205

Changes proposed in this pull request:
- Changes default from swap partition to /var/swapfile
- Default swapfile size can be overridden via YAML or command line
- Improves media selection logging; why media is not usable
- Relies upon systemd patch to detect and swap on /var/swapfile (since Clear Linux OS 32770)


