### PR TITLE
Make destructive install smart 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ script:
     - docker exec -it clear-test bash -c "cd /travis ; MAKEFLAGS=-j$(nproc) make install-linters-force"
     - travis_wait 30 sleep infinity & docker exec -it clear-test bash -c "cd /travis ; make lint"
     - travis_retry docker exec -it clear-test bash -c "cd /travis ; MAKEFLAGS=-j$(nproc) make check"
-    - travis_retry docker exec -it clear-test bash -c "cd /travis ; MAKEFLAGS=-j$(nproc) make functional-check"
     - docker exec -it clear-test bash -c "cd /travis ; MAKEFLAGS=-j$(nproc) make check-clean"
     - travis_retry docker exec -it clear-test bash -c "cd /travis ; MAKEFLAGS=-j$(nproc) make check-image"
     - docker exec -it clear-test bash -c "cd /travis ; MAKEFLAGS=-j$(nproc) make clean"

--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ endif
 
 
 PHONY += functional-check
-functional-check: check-for-root-user
+functional-check: check-for-root-user build
 	@for test in $$(find $$FUNCTIONAL_TEST_DIR -name "*.bats" | sort); do \
 		echo "Running $$test"; \
 		bats $$test; \

--- a/args/args.go
+++ b/args/args.go
@@ -99,6 +99,7 @@ type Args struct {
 	SkipValidationAll       bool
 	SkipValidationAllSet    bool
 	SwapFileSize            string
+	ForceDestructive        bool
 }
 
 func (args *Args) setKernelArgs() (err error) {
@@ -422,6 +423,13 @@ func (args *Args) setCommandLineArgs() (err error) {
 
 	flag.StringVar(
 		&args.SwapFileSize, "swap-file-size", args.SwapFileSize, "Size of the swapfile; <size>[B|K|M|G]",
+	)
+
+	flag.BoolVar(
+		&args.ForceDestructive, "force-destructive",
+		false,
+		"Enable destructive installation which may cause data loss on unselected media;"+
+			" "+"RAID, lvm etc. Proceed with caution!",
 	)
 
 	spflag.ErrHelp = errors.New("Clear Linux Installer program")

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -445,6 +445,10 @@ func processOptionsSaveIfSet(options args.Args, md *model.SystemInstall) {
 		md.MediaOpts.SwapFileSize = options.SwapFileSize
 		md.MediaOpts.SwapFileSet = true
 	}
+
+	if options.ForceDestructive {
+		md.MediaOpts.ForceDestructive = options.ForceDestructive
+	}
 }
 
 func processOptionsToModel(options args.Args, md *model.SystemInstall) {

--- a/completions/zsh/_clr-installer
+++ b/completions/zsh/_clr-installer
@@ -57,6 +57,7 @@ local -a global_opts; global_opts=(
                true\:Reboot\ after\ finishing\ \(default\)
                false\:Don\`t\ reboot\ after\ finishing))'
   '--skip-validation-size[Skip the partition validation size check]'
+  '--force-destructive[Force destructive install..Proceed with caution]'
   '(-S --stub-image)'{-S,--stub-image}'[Creates the filesystems only - dont perform an actual install]'
   '--swap-file-size[Size of the swapfile]:swapfile size: _message -r "<size>[B|K|M|G]"'
   '--swupd-cert[Specify alternative path to swupd certificates]:swupd certification path: _files -/'

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -844,24 +844,22 @@ msgstr "Creating %s"
 #, c-format
 msgid "Setting boot partition: %s"
 msgstr "Setting boot partition: %s"
-<<<<<<< HEAD
-=======
 
 #, c-format
 msgid "Cleaning disk %s"
 msgstr "Cleaning disk %s"
 
 #, c-format
-msgid "This will degrade RAID: %s"
-msgstr "This will degrade RAID: %s"
+msgid "Degrading RAID: %s"
+msgstr "Degrading RAID: %s"
 
 #, c-format
 msgid "Remove partition from RAID %s"
 msgstr "Remove partition from RAID %s"
 
 #, c-format
-msgid "Raid [%s]: has parts from other disks: [%s]"
-msgstr "Raid [%s]: has parts from other disks: [%s]"
+msgid "RAID %s: has parts from other disks: [%s]"
+msgstr "RAID %s: has parts from other disks: [%s]"
 
 #, c-format
 msgid "Remove physical volume: %s from volume group: %s"
@@ -889,4 +887,5 @@ msgstr "Effect on Other Disks:"
 msgid "Resolve above issues or use --force-destructive option"
 msgstr "Resolve above issues or use --force-destructive option"
 
->>>>>>> c32484f... storage: All Misc fixes
+msgid "CAUTION: You are using --force-destructive option; Above Issues will be resolved automatically"
+msgstr "CAUTION: You are using --force-destructive option; Above Issues will be resolved automatically"

--- a/locale/en_US/LC_MESSAGES/clr-installer.po
+++ b/locale/en_US/LC_MESSAGES/clr-installer.po
@@ -844,3 +844,49 @@ msgstr "Creating %s"
 #, c-format
 msgid "Setting boot partition: %s"
 msgstr "Setting boot partition: %s"
+<<<<<<< HEAD
+=======
+
+#, c-format
+msgid "Cleaning disk %s"
+msgstr "Cleaning disk %s"
+
+#, c-format
+msgid "This will degrade RAID: %s"
+msgstr "This will degrade RAID: %s"
+
+#, c-format
+msgid "Remove partition from RAID %s"
+msgstr "Remove partition from RAID %s"
+
+#, c-format
+msgid "Raid [%s]: has parts from other disks: [%s]"
+msgstr "Raid [%s]: has parts from other disks: [%s]"
+
+#, c-format
+msgid "Remove physical volume: %s from volume group: %s"
+msgstr "Remove physical volume: %s from volume group: %s"
+
+#, c-format
+msgid "Volume group: %s has physical volumes from other disks: [%s]"
+msgstr "Volume group: %s has physical volumes from other disks: [%s]"
+
+#, c-format
+msgid "Remove volume group: %s"
+msgstr "Remove volume group: %s"
+
+#, c-format
+msgid "Remove physical volume: %s"
+msgstr "Remove physical volume: %s"
+
+#, c-format
+msgid "Remove volumes: [%s]"
+msgstr "Remove volumes: [%s]"
+
+msgid "Effect on Other Disks:"
+msgstr "Effect on Other Disks:"
+
+msgid "Resolve above issues or use --force-destructive option"
+msgstr "Resolve above issues or use --force-destructive option"
+
+>>>>>>> c32484f... storage: All Misc fixes

--- a/locale/es_MX/LC_MESSAGES/clr-installer.po
+++ b/locale/es_MX/LC_MESSAGES/clr-installer.po
@@ -844,3 +844,48 @@ msgstr "Crear %s"
 #, c-format
 msgid "Setting boot partition: %s"
 msgstr "Estableciendo partición de arranque: %s"
+
+#, c-format
+msgid "Cleaning disk %s"
+msgstr "Disco de limpieza %s"
+
+#, c-format
+msgid "Degrading RAID: %s"
+msgstr "Degradante RAID: %s"
+
+#, c-format
+msgid "Remove partition from RAID %s"
+msgstr "Eliminar partición de RAID %s"
+
+#, c-format
+msgid "RAID %s: has parts from other disks: [%s]"
+msgstr "RAID %s: tiene partes de otros discos: [%s]"
+
+#, c-format
+msgid "Remove physical volume: %s from volume group: %s"
+msgstr "Eliminar physical volume: %s from volume group: %s"
+
+#, c-format
+msgid "Volume group: %s has physical volumes from other disks: [%s]"
+msgstr "Volumen grupo: %s tiene volúmenes físicos de otros discos: [%s]"
+
+#, c-format
+msgid "Remove volume group: %s"
+msgstr "Eliminar Volumen grupo: %s"
+
+#, c-format
+msgid "Remove physical volume: %s"
+msgstr "Eliminar Volumen fisico: %s"
+
+#, c-format
+msgid "Remove volumes: [%s]"
+msgstr "Eliminar Volúmenes: [%s]"
+
+msgid "Effect on Other Disks:"
+msgstr "Efecto en otros discos:"
+
+msgid "Resolve above issues or use --force-destructive option"
+msgstr "Resolver problemas anteriores o opción de uso --force-destructive"
+
+msgid "CAUTION: You are using --force-destructive option; Above Issues will be resolved automatically"
+msgstr "Precaución: Tu estas usando --force-destructive opción; Los problemas anteriores se resolverán automáticamente"

--- a/locale/zh_CN/LC_MESSAGES/clr-installer.po
+++ b/locale/zh_CN/LC_MESSAGES/clr-installer.po
@@ -844,3 +844,48 @@ msgstr "创建 %s"
 #, c-format
 msgid "Setting boot partition: %s"
 msgstr "设置启动分区：%s"
+
+#, c-format
+msgid "Cleaning disk %s"
+msgstr "清洁盘 %s"
+
+#, c-format
+msgid "Degrading RAID: %s"
+msgstr "降级 RAID: %s"
+
+#, c-format
+msgid "Remove partition from RAID %s"
+msgstr "从中删除分区 RAID %s"
+
+#, c-format
+msgid "RAID %s: has parts from other disks: [%s]"
+msgstr "RAID %s: 带有其他磁盘的零件： [%s]"
+
+#, c-format
+msgid "Remove physical volume: %s from volume group: %s"
+msgstr "移除物理体积: %s 来自卷组: %s"
+
+#, c-format
+msgid "Volume group: %s has physical volumes from other disks: [%s]"
+msgstr "卷组: %s 在其他磁盘上有物理卷: [%s]"
+
+#, c-format
+msgid "Remove volume group: %s"
+msgstr "删除卷组: %s"
+
+#, c-format
+msgid "Remove physical volume: %s"
+msgstr "移除物理体积: %s"
+
+#, c-format
+msgid "Remove volumes: [%s]"
+msgstr "删除卷: [%s]"
+
+msgid "Effect on Other Disks:"
+msgstr "对其他磁盘的影响:"
+
+msgid "Resolve above issues or use --force-destructive option"
+msgstr "解决以上问题 或使用 --force-destructive 选项"
+
+msgid "CAUTION: You are using --force-destructive option; Above Issues will be resolved automatically"
+msgstr "警告: 您正在使用 --force-destructive 选项 以上问题将自动解决"

--- a/storage/block_devices.go
+++ b/storage/block_devices.go
@@ -273,6 +273,10 @@ func (bd BlockDevice) GetMappedDeviceFile() string {
 		return filepath.Join("/dev/", bd.MappedName)
 	}
 
+	if bd.Type == BlockDeviceTypeLVM2Volume {
+		return filepath.Join("/dev/mapper", bd.Name)
+	}
+
 	return filepath.Join("/dev/", bd.Name)
 }
 

--- a/storage/block_devices.go
+++ b/storage/block_devices.go
@@ -721,3 +721,15 @@ func (bd *BlockDevice) IsAdvancedConfiguration() bool {
 
 	return advanced
 }
+
+func (bd *BlockDevice) isRaidType() bool {
+	if bd.Type == BlockDeviceTypeRAID0 ||
+		bd.Type == BlockDeviceTypeRAID1 ||
+		bd.Type == BlockDeviceTypeRAID4 ||
+		bd.Type == BlockDeviceTypeRAID5 ||
+		bd.Type == BlockDeviceTypeRAID6 ||
+		bd.Type == BlockDeviceTypeRAID10 {
+		return true
+	}
+	return false
+}

--- a/storage/block_devices.go
+++ b/storage/block_devices.go
@@ -199,6 +199,9 @@ var (
 
 	bootSizeDefault     = uint64(150 * (1024 * 1024))
 	SwapFileSizeDefault = uint64(64 * (1024 * 1024))
+
+	// BlockDeviceTypeLVM2GroupString is a string version for LVM2 member type
+	BlockDeviceTypeLVM2GroupString, _ = blockDeviceTypeMap[BlockDeviceTypeLVM2Group]
 )
 
 func getAliasSuffix(file string) string {

--- a/storage/block_devices_filters.go
+++ b/storage/block_devices_filters.go
@@ -58,7 +58,7 @@ func FindBlockDeviceDepthFirst(bd *BlockDevice, filterfunc BlockDevFilterFunc) (
 }
 
 // FindAllBlockDevices runs the filterfunc and returns a list of all blockdevices which
-// satisfy the condition
+// satisfy the condition. This tree is flattened. So dont use children of each item in list
 func FindAllBlockDevices(bd *BlockDevice, filterfunc BlockDevFilterFunc) []*BlockDevice {
 	var result []*BlockDevice = []*BlockDevice{}
 

--- a/storage/block_devices_filters.go
+++ b/storage/block_devices_filters.go
@@ -35,3 +35,40 @@ func FilterBlockDevices(bd []*BlockDevice, filterfunc ...BlockDevFilterFunc) []*
 	}
 	return workingBDList
 }
+
+// FindBlockDeviceDepthFirst runs the filterfunc in depth first manner and returns the first child
+// which shows certain property
+func FindBlockDeviceDepthFirst(bd *BlockDevice, filterfunc BlockDevFilterFunc) (bool, *BlockDevice) {
+	var result *BlockDevice = nil
+	var found bool = false
+
+	if filterfunc(bd) {
+		return true, bd
+	}
+
+	for _, child := range bd.Children {
+		found, result = FindBlockDeviceDepthFirst(child, filterfunc)
+
+		if found {
+			break
+		}
+	}
+
+	return found, result
+}
+
+// FindAllBlockDevices runs the filterfunc and returns a list of all blockdevices which
+// satisfy the condition
+func FindAllBlockDevices(bd *BlockDevice, filterfunc BlockDevFilterFunc) []*BlockDevice {
+	var result []*BlockDevice = []*BlockDevice{}
+
+	if filterfunc(bd) {
+		result = append(result, bd)
+	}
+
+	for _, child := range bd.Children {
+		result = append(result, FindAllBlockDevices(child, filterfunc)...)
+	}
+
+	return result
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -553,13 +553,13 @@ func TestWritePartition(t *testing.T) {
 		bd.Children = children
 
 		//write the partition table (dryrun)
-		results := []string{}
-		if err = bd.WritePartitionTable(true, &results); err != nil {
+		var dryRun *DryRunType = &DryRunType{&[]string{}, &[]string{}}
+		if err = bd.WritePartitionTable(true, false, dryRun); err != nil {
 			t.Fatalf("Could not dryrun write partition table (%s): %s", file, err)
 		}
 
 		//write the partition table
-		if err = bd.WritePartitionTable(true, nil); err != nil {
+		if err = bd.WritePartitionTable(true, false, nil); err != nil {
 			t.Fatalf("Could not write partition table (%s): %s", file, err)
 		}
 

--- a/tests/functional/install/basic.bats
+++ b/tests/functional/install/basic.bats
@@ -5,27 +5,24 @@
 
 load "../testlib"
 
-global_setup() {
-    create_testworking_dir
-}
+test_setup() {
 
-global_teardown() {
-    clean_testworking_dir
+    create_testworking_dir
+    qemu-img create -f raw "$TESTWORKINGDIR"/testimgfile.img 5G
+    loopbackdevice=$(losetup --partscan --find --show "$TESTWORKINGDIR"/testimgfile.img)
+
 }
 
 test_teardown() {
-    losetup -d "$loopbackdevice"
+
+    losetup -d "$loopbackdevice" || true
+    clean_testworking_dir
+    
 }
 
 @test "INSTALL001: Basic Install" {
     
-    qemu-img create -f raw "$TESTWORKINGDIRECTORY"/testimgfile.img 5G
-    
-    loopbackdevice=$(losetup --partscan --find --show "$TESTWORKINGDIRECTORY"/testimgfile.img)
-    export loopbackdevice
-
     run sh -c "$CLR_INSTALLER_EXE -c $TESTSCRIPTS/basic.yaml -b installer:${loopbackdevice}"
-
     assert_status_is "0"
 
 }

--- a/tests/functional/install/destructive_LVM_RAID_combination.bats
+++ b/tests/functional/install/destructive_LVM_RAID_combination.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+
+# Author: Karthik Prabhu Vinod
+# Email: karthik.prabhu.vinod@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+    create_testworking_dir
+    qemu-img create -f raw "$TESTWORKINGDIR"/loop_disk1 1G
+    qemu-img create -f raw "$TESTWORKINGDIR"/loop_disk2 6G
+    qemu-img create -f raw "$TESTWORKINGDIR"/loop_disk3 9G
+
+    # loopback disk1
+    loop_device_disk1=$(losetup --partscan --find --show "$TESTWORKINGDIR"/loop_disk1)
+    # loopback disk2
+    loop_device_disk2=$(losetup --partscan --find --show "$TESTWORKINGDIR"/loop_disk2)
+    # loopback disk3 
+    loop_device_disk3=$(losetup --partscan --find --show "$TESTWORKINGDIR"/loop_disk3)
+
+    # create part from disk1
+    parted "${loop_device_disk1}" mklabel gpt
+    fdisk -u -w always -W always "$loop_device_disk1" <<EOF
+n
+
+
+
+w
+EOF
+
+    # create part from disk2
+    parted "${loop_device_disk2}" mklabel gpt
+    fdisk -u -w always -W always "$loop_device_disk2" <<EOF
+n
+
+
+
+w
+EOF
+
+    # create part from disk3
+    parted "${loop_device_disk3}" mklabel gpt
+    fdisk -u -w always -W always "$loop_device_disk3" <<EOF
+n
+
+
++1G
+n
+
+
++6G
+w
+EOF
+
+    # Create raid md3 based on disk1 disk3
+    echo y | mdadm --create /dev/md3 --level=1 --raid-devices=2 "$loop_device_disk1" "${loop_device_disk3}"p1 --force
+    # Create raid md4 based on disk2 disk3
+    echo y | mdadm --create /dev/md4 --level=1 --raid-devices=2 "$loop_device_disk2" "${loop_device_disk3}"p2 --force
+    
+    # Required for raid devices to be ready
+    wait_for_raid_to_be_active "/dev/md3"
+    wait_for_raid_to_be_active "/dev/md4"
+
+    # create three LVMS on md3 which get replicated on disk1 and disk3
+    parted "/dev/md3" mklabel gpt
+    fdisk -u -w always -W always /dev/md3 <<EOF
+n
+
+
+
+w
+EOF
+
+    pvcreate -ff /dev/md3p1 3>&-
+    vgcreate -y TESTVG /dev/md3p1 3>&-
+    lvcreate --wipesignatures y -n testraid3lv1 TESTVG -l 30%VG 3>&-
+    lvcreate --wipesignatures y -n testraid3lv2 TESTVG -l 30%VG 3>&-
+    lvcreate --wipesignatures y -n testraid3lv3 TESTVG -l 30%VG 3>&-
+
+    # create three LVMS on md4 which get replicated on disk2 and disk3
+    parted "/dev/md4" mklabel gpt
+    fdisk -u -w always -W always /dev/md4 <<EOF
+n
+
+
+
+w
+EOF
+
+    pvcreate -ff /dev/md4p1 3>&-
+    vgextend -y TESTVG /dev/md4p1 3>&-
+    lvcreate --wipesignatures y -n testraid4lv1 TESTVG -l 30%VG 3>&-
+    lvcreate --wipesignatures y -n testraid4lv2 TESTVG -l 30%VG 3>&-
+    lvcreate --wipesignatures y -n testraid4lv3 TESTVG -l 30%VG 3>&-
+
+    # Required for raid devices to be ready
+    wait_for_raid_to_be_active /dev/md3
+    wait_for_raid_to_be_active /dev/md4
+
+}
+
+test_teardown() {
+
+    #Cleanup
+    lvremove -y /dev/mapper/TESTVG-testlv1 /dev/mapper/TESTVG-testlv2 /dev/mapper/TESTVG-testlv3 3>&- || true
+    vgremove -y TESTVG 3>&- || true
+    pvremove -y /dev/md4p1 3>&- || true
+
+    mdadm --stop /dev/md3 || true
+    mdadm --stop /dev/md4 || true
+
+    losetup -d "$loop_device_disk1" 3>&- || true
+    losetup -d "$loop_device_disk2" 3>&- || true
+    losetup -d "$loop_device_disk3" 3>&- || true
+
+    rm -r "$TESTWORKINGDIR"/{loop_disk1,loop_disk2,loop_disk3} || true
+
+    clean_testworking_dir
+
+}
+
+
+#------------------------------------
+# LVM and RAID combination
+#------------------------------------
+#NAME                        MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINT
+#loop0                         7:0    0     1G  0 loop  
+#└─md3                         9:3    0  1022M  0 raid1 
+#  └─md3p1                   259:7    0  1021M  0 part  
+#    ├─TESTVG-testraid3lv1   252:0    0   304M  0 lvm   
+#    ├─TESTVG-testraid3lv2   252:1    0   304M  0 lvm   
+#    └─TESTVG-testraid3lv3   252:2    0   304M  0 lvm   
+#loop1                         7:1    0    10G  0 loop  
+#└─md4                         9:4    0    10G  0 raid1 
+#  └─md4p1                   259:8    0    10G  0 part  
+#    ├─TESTVG-testraid4lv1   252:3    0   3.3G  0 lvm   
+#    ├─TESTVG-testraid4lv2   252:4    0   3.3G  0 lvm   
+#    └─TESTVG-testraid4lv3   252:5    0   3.3G  0 lvm   
+#loop2                         7:2    0    30G  0 loop  
+#├─loop2p1                   259:5    0     1G  0 part  
+#│ └─md3                       9:3    0  1022M  0 raid1 
+#│   └─md3p1                 259:7    0  1021M  0 part  
+#│     ├─TESTVG-testraid3lv1 252:0    0   304M  0 lvm   
+#│     ├─TESTVG-testraid3lv2 252:1    0   304M  0 lvm   
+#│     └─TESTVG-testraid3lv3 252:2    0   304M  0 lvm   
+#└─loop2p2                   259:6    0    10G  0 part  
+#  └─md4                       9:4    0    10G  0 raid1 
+#    └─md4p1                 259:8    0    10G  0 part  
+#      ├─TESTVG-testraid4lv1 252:3    0   3.3G  0 lvm   
+#      ├─TESTVG-testraid4lv2 252:4    0   3.3G  0 lvm   
+#      └─TESTVG-testraid4lv3 252:5    0   3.3G  0 lvm
+@test "INSTALL004: Destructive Install LVM and RAID combination" {
+
+    run sh -c "$CLR_INSTALLER_EXE -c $TESTSCRIPTS/basic.yaml -b installer:${loop_device_disk3} --force-destructive"
+    assert_status_is "0"
+
+}

--- a/tests/functional/install/destructive_LVM_across_multiple_disks.bats
+++ b/tests/functional/install/destructive_LVM_across_multiple_disks.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+
+# Author: Karthik Prabhu Vinod
+# Email: karthik.prabhu.vinod@intel.com
+
+load "../testlib"
+
+test_setup() {
+    if [ -n "$TRAVIS" ]; then
+        skip "This test does not run well in travis. We can test this locally"
+    fi
+
+    create_testworking_dir
+    #test setup
+
+    # Disk 1
+    qemu-img create -f raw "$TESTWORKINGDIR"/loopdevice.img 5G
+    loop_device_disk1=$(losetup --partscan --find --show "$TESTWORKINGDIR"/loopdevice.img)
+
+    #Disk 2
+    qemu-img create -f raw "$TESTWORKINGDIR"/loopdevice2.img 5G
+    loop_device_disk2=$(losetup --partscan --find --show "$TESTWORKINGDIR"/loopdevice2.img)
+
+    # Creating a part of LVM2_member type on Disk1
+    fdisk -u -w always -W always ${loop_device_disk1} <<EOF
+n
+p
+
+
+
+t
+8e
+w
+EOF
+
+    # Creating a part of LVM2_member type on Disk2
+    fdisk -u -w always -W always ${loop_device_disk2} <<EOF
+n
+p
+
+
+
+t
+8e
+w
+EOF
+
+    pvcreate -ff "$loop_device_disk1"p1 3>&-
+    pvcreate -ff "$loop_device_disk2"p1 3>&-
+    vgcreate -y dockershared "$loop_device_disk1"p1 "$loop_device_disk2"p1 3>&-
+
+    lvcreate --wipesignatures y -n lv1 dockershared -l 30%VG 3>&-
+    lvcreate --wipesignatures y -n lv2 dockershared -l 30%VG 3>&-
+    lvcreate --wipesignatures y -n lv3 dockershared -l 40%VG 3>&-
+
+}
+
+test_teardown() {
+
+    #test cleanup
+    lvremove -y /dev/mapper/dockershared-lv1 3>&- || true
+    lvremove -y /dev/mapper/dockershared-lv2 3>&- || true
+    lvremove -y /dev/mapper/dockershared-lv3 3>&- || true
+    vgremove -y dockershared 3>&- || true
+    pvremove -y "$loop_device_disk1"p1 || true
+    pvremove -y "$loop_device_disk2"p1 || true
+
+    losetup -d $loop_device_disk1 || true
+    losetup -d $loop_device_disk2 || true
+
+    rm -r "$TESTWORKINGDIR"/loopdevice.img || true
+    rm -r "$TESTWORKINGDIR"/loopdevice2.img || true
+
+    clean_testworking_dir
+
+}
+
+#------------------------------------
+# LVM across multiple disks
+#------------------------------------
+#NAME                 MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
+#loop0                  7:0    0    15G  0 loop 
+#└─loop0p1            259:5    0    15G  0 part 
+#  ├─dockershared-lv1 252:0    0     9G  0 lvm  
+#  └─dockershared-lv3 252:2    0    12G  0 lvm  
+#loop1                  7:1    0    15G  0 loop 
+#└─loop1p1            259:6    0    15G  0 part 
+#  ├─dockershared-lv2 252:1    0     9G  0 lvm  
+#  └─dockershared-lv3 252:2    0    12G  0 lvm  
+@test "INSTALL002: Destructive Install LVM across two disks" {
+
+    # test
+    # Fail without force-destructive
+    run sh -c "$CLR_INSTALLER_EXE -c $TESTSCRIPTS/basic.yaml -b installer:${loop_device_disk2}"
+    assert_status_is_not "0"
+
+    # Succeed with force-destructive
+    run sh -c "$CLR_INSTALLER_EXE -c $TESTSCRIPTS/basic.yaml -b installer:${loop_device_disk2} --force-destructive"
+    assert_status_is "0"
+
+}

--- a/tests/functional/install/destructive_LVM_managed_thinpool.bats
+++ b/tests/functional/install/destructive_LVM_managed_thinpool.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+# Author: Karthik Prabhu Vinod
+# Email: karthik.prabhu.vinod@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+   # skip test if dm-thin-pool module not present
+   if [[ ! $(modinfo dm-thin-pool) ]]; then
+      skip "This test does not run well in travis. We can test this locally"
+   fi
+
+    create_testworking_dir
+    #test setup
+    # Disk 1
+    qemu-img create -f raw "$TESTWORKINGDIR"/loopdevice.img 15G
+    loop_device_disk=$(losetup --partscan --find --show "$TESTWORKINGDIR"/loopdevice.img)
+
+    # Creating a part of LVM2_member type on Disk1
+    parted "${loop_device_disk}" mklabel gpt
+
+    fdisk -u -w always -W always ${loop_device_disk} <<EOF
+n
+
+
+
+w
+EOF
+    pvcreate -ff "$loop_device_disk"p1 3>&-
+    vgcreate -y docker "$loop_device_disk"p1 3>&-
+    lvcreate --wipesignatures y -n thinpool docker -l 95%VG 3>&-
+    lvcreate --wipesignatures y -n thinpoolmeta docker -l 1%VG 3>&-
+    lvconvert -y --zero n -c 512K --thinpool docker/thinpool --poolmetadata docker/thinpoolmeta 3>&-
+
+}
+
+test_teardown() {
+
+    #test cleanup
+    lvremove -y /dev/mapper/docker-thinpool 3>&- || true
+    vgremove -y docker 3>&- || true
+    pvremove -y "$loop_device_disk"p1 || true
+    losetup -d "$loop_device_disk" || true
+    rm -r "$TESTWORKINGDIR"/loopdevice.img  || true
+    clean_testworking_dir
+
+}
+
+#------------------------------------
+# Managed LVM thinpool 
+#------------------------------------
+#NAME                      MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
+#loop0                       7:0    0    30G  0 loop 
+#└─loop0p1                 259:5    0    30G  0 part 
+#  ├─docker-thinpool_tmeta 252:0    0   304M  0 lvm  
+#  │ └─docker-thinpool     252:2    0  28.5G  0 lvm  
+#  └─docker-thinpool_tdata 252:1    0  28.5G  0 lvm  
+#    └─docker-thinpool     252:2    0  28.5G  0 lvm
+# Issue 633 
+@test "INSTALL003: Destructive Install Managed LVM thinpool" {
+
+    # test
+    # Succeed with force-destructive
+    run sh -c "$CLR_INSTALLER_EXE -c $TESTSCRIPTS/basic.yaml -b installer:${loop_device_disk}"
+    assert_status_is "0"
+
+}

--- a/tests/functional/testlib.bash
+++ b/tests/functional/testlib.bash
@@ -1,13 +1,14 @@
 #!/usr/bin/bash
 
-# global variables
 top_srcdir="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../ && pwd)"
 export top_srcdir
-export FUNCTIONAL_TEST_DIR="$top_srcdir/tests/functional"
-export CLR_INSTALLER_EXE="$top_srcdir/.gopath/bin/clr-installer"
-export SCRIPTS="$top_srcdir/scripts"
-export TESTSCRIPTS="$top_srcdir/tests"
-export TESTWORKINGDIRECTORY="$top_srcdir/testworking"
+export FUNCTIONAL_TEST_DIR="${top_srcdir}/tests/functional"
+export CLR_INSTALLER_EXE="${top_srcdir}/.gopath/bin/clr-installer"
+export SCRIPTS="${top_srcdir}/scripts"
+export TESTSCRIPTS="${top_srcdir}/tests"
+export TESTWORKINGDIRBASENAME="${top_srcdir}/test"
+
+# global variables
 
 setup() {
     global_setup
@@ -40,6 +41,30 @@ test_teardown() {
 	echo "No test_teardown was defined"
 }
 
+assert_status_is_not() { # assertion
+
+	local not_expected_status=$1
+
+	if [ -z "$status" ]; then
+		echo "The \$status environment variable is empty."
+		echo "Please make sure this assertion is used inside a BATS test after a 'run' command."
+		return 1
+	fi
+
+	if [ "$status" -eq "$not_expected_status" ]; then
+		print_assert_failure "Status expected to be different than: $not_expected_status\\nActual status: $status"
+		return 1
+	else
+		# if the assertion was successful show the output only if the user
+		# runs the test with the -t flag
+		echo -e "\\nCommand output:" >&3
+		echo "------------------------------------------------------------------" >&3
+		echo "$output" >&3
+		echo -e "------------------------------------------------------------------\\n" >&3
+	fi
+
+}
+
 assert_status_is() { # assertion
 
 	local expected_status=$1
@@ -64,11 +89,74 @@ assert_status_is() { # assertion
 
 }
 
-create_testworking_dir(){
-	mkdir -p "$TESTWORKINGDIRECTORY"
+# Parameters: Raid device to be checked
+# usage: wait_for_raid_to_be_active <raid_dev_name>
+wait_for_raid_to_be_active() {
+    let timeoutval=`expr 3 \* 60`
+    let interval=1
+    local raiddev=$1
+
+    if [ -z "$raiddev" ]; then
+        echo "RAID device name cant be empty" >&3
+        exit 1
+    fi
+
+    if [ ! $mdadm --detail $raiddev ]; then
+        echo "Invalid RAID device" >&3
+        exit 1
+    fi
+
+    while [ "$timeoutval" -gt "0" ]
+    do
+        if [[ $(mdadm --detail $raiddev | grep -e "State : clean $") ]]; then
+            break
+        else
+            echo "Waiting for RAID to be active" >&3
+            sleep "$interval"
+            timeoutval=`expr "$timeoutval" - "$interval"`
+        fi
+    done
+
+    if [ "$timeoutval" -lt "0" ]; then
+        echo "The wait timed out" >&3
+        exit 1
+    fi
+
 }
 
-clean_testworking_dir(){
-	rm -r "$TESTWORKINGDIRECTORY"
+create_testworking_dir() {
+	local testdirname=$(echo $$)
+
+	if [ -z "$testdirname" ]; then
+        echo "Test dir name cant be empty" >&3
+        exit 1
+    fi
+
+	local TESTDIRPATH=${TESTWORKINGDIRBASENAME}_${testdirname}
+
+	if [ ! -d "$TESTDIRPATH" ]; then
+		mkdir -p "$TESTDIRPATH"
+		export TESTWORKINGDIR=${TESTDIRPATH}
+	else
+		echo "Fail to create test directory: ${TESTDIRPATH}" >&3
+		exit 1
+	fi
+}
+
+clean_testworking_dir() {
+
+	if [ -z "${TESTWORKINGDIR}" ]; then
+        echo "TEST Directory not set" >&3
+        exit 1
+    fi
+
+	if [ -d "$TESTWORKINGDIR" ]; then
+		rm -r "$TESTWORKINGDIR"
+		unset ${TESTWORKINGDIR}
+	else
+		echo "Fail to delete test directory" >&3
+		exit 1
+	fi
+
 }
 


### PR DESCRIPTION
Signed-off-by: Karthik Prabhu Vinod <karthik.prabhu.vinod@intel.com>

Fixes Issue: #633 

Changes proposed in this pull request:
- Make sure we present users with ample and concise warnings
- Take action to tear apart layer by layer
- Fail destructive installation if it affects parts of other disks
- Add a force-destructive-install option to allow proceeding with installs which have ill-effects on other disks


