### PR TITLE
storage: Include clr-init for software RAID

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -64,7 +64,7 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 	var err error
 	var version string
 	var prg progress.Progress
-	var encryptedUsed bool
+	var encryptedUsed, softRaidUsed bool
 
 	vars := map[string]string{
 		"chrootDir": rootDir,
@@ -245,6 +245,9 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 			return err
 		}
 
+		// Are we using software RAID
+		softRaidUsed = softRaidUsed || curr.UsesRaid()
+
 		// prepare the blockdevice's partitions filesystem
 		for _, ch := range curr.Children {
 			if ch.Type == storage.BlockDeviceTypeCrypt {
@@ -354,8 +357,10 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		model.AddBundle(language.RequiredBundle)
 	}
 
-	if encryptedUsed {
+	if encryptedUsed || softRaidUsed {
 		model.AddBundle(storage.RequiredBundle)
+	}
+	if encryptedUsed {
 		kernelArgs := []string{storage.KernelArgument}
 		model.AddExtraKernelArguments(kernelArgs)
 	}

--- a/storage/block_devices.go
+++ b/storage/block_devices.go
@@ -386,6 +386,27 @@ func (bd *BlockDevice) FsTypeNotSwap() bool {
 	return bd.FsType != "swap"
 }
 
+// UsesRaid returns true if the file system type is any known RAID type
+func (bd *BlockDevice) UsesRaid() bool {
+
+	if bd.Type == BlockDeviceTypeRAID0 ||
+		bd.Type == BlockDeviceTypeRAID1 ||
+		bd.Type == BlockDeviceTypeRAID4 ||
+		bd.Type == BlockDeviceTypeRAID5 ||
+		bd.Type == BlockDeviceTypeRAID6 ||
+		bd.Type == BlockDeviceTypeRAID10 {
+		return true
+	}
+
+	for _, curr := range bd.Children {
+		if curr.UsesRaid() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // RemoveChild removes a partition from disk block device
 func (bd *BlockDevice) RemoveChild(child *BlockDevice) {
 	copyBd := bd.Clone()


### PR DESCRIPTION
Partially Addresses: #8

Changes proposed in this pull request:
- If software RAID is used for one of the target install media, include the bundle with clr-init.


