### PR TITLE
completions: Added Completions for bash and zsh

### DIFF
--- a/completions/bash/clr-installer
+++ b/completions/bash/clr-installer
@@ -24,7 +24,7 @@ _clr_installer() {
   _init_completion -s || return
 
   case "$prev" in
-    --archive|--copy-network|--iso|--keep-image|--reboot|--stub-image|--swupd-skip-diskspace-check|--telemetry)
+    --archive|--copy-network|--copy-swupd|--keep-image|--reboot|--swupd-skip-diskspace-check)
       COMPREPLY=($(compgen -W "true false" -- "$cur"))
       return
       ;;
@@ -43,22 +43,26 @@ _clr_installer() {
       return
       ;;
     --config)
-      COMPREPLY=($(compgen -f -X "!*.yaml" -- "$cur"))
+      _filedir yaml
       return
       ;;
     --json-yaml)
-      COMPREPLY=($(compgen -f -X "!*.json" -- "$cur"))
+      _filedir json
       return
       ;;
     --crypt-file|--log-file)
       COMPREPLY=($(compgen -f -- "$cur"))
       return
       ;;
-    --swupd-cert|--swupd-state)
+    --swupd-cert)
+      _filedir pem
+      return
+      ;;
+    --swupd-state)
       COMPREPLY=($(compgen -d -- "$cur"))
       return
       ;;
-    --swupd-contenturl|--swupd-mirror|--swupd-versionurl|--telemetry-url)
+    --swupd-url|--swupd-contenturl|--swupd-mirror|--swupd-versionurl|--telemetry-url)
       # a zero-width space before `h`, and at the last character
       opts='​https://...  '
       COMPREPLY=($(compgen -W "$opts" -- "$cur"))
@@ -82,6 +86,8 @@ _clr_installer() {
         ​d*)
           opts="4"
           COMPREPLY=($(compgen -W "$opts" -- "$opts"))
+          ;;
+        -B|--bundles)
           ;;
         *)
           # a zero-width space before each alternative

--- a/completions/bash/clr-installer
+++ b/completions/bash/clr-installer
@@ -1,0 +1,108 @@
+#!/bin/bash
+# shellcheck disable=SC2207
+# -----------------------------------------------------------------------
+#   Clear Linux OS* Installer - autocompletion script
+#
+#   Author: Lucius Hu - http://github.com/lebensterben
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, version 2 or later of the License.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------
+
+_clr_installer() {
+  local IFS opts prev cur
+
+  _init_completion -s || return
+
+  case "$prev" in
+    --archive|--copy-network|--iso|--keep-image|--reboot|--stub-image|--swupd-skip-diskspace-check|--telemetry)
+      COMPREPLY=($(compgen -W "true false" -- "$cur"))
+      return
+      ;;
+    --block-device)
+      local blockdevice; blockdevice="$(lsblk --noheadings --raw --paths | cut -d' ' -f1 | tr '\n' ',')"
+      # The trick is to insert any UNICODE space(s), e.g. non-breaking space, before the message
+      #    so that 'word' is not likely to be matched by a user's input
+      # And add at least one other 'word' start with any UNICODE space(s)
+      #    otherwise completion system will push the only candidate to the command line
+      # The drawback is, this special character may not shown correctly, for example in `tty`, it's
+      #    it's shown as a rectangle
+
+      # here, before F and B, there is a UNICODE tag space U+E0020
+      opts="󠀠Format:\"alias1:filename1[,alias2:filename2,...]\" 󠀠BlockDevices:${blockdevice:0:-1}"
+      COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+      return
+      ;;
+    --config)
+      COMPREPLY=($(compgen -f -X "!*.yaml" -- "$cur"))
+      return
+      ;;
+    --json-yaml)
+      COMPREPLY=($(compgen -f -X "!*.json" -- "$cur"))
+      return
+      ;;
+    --crypt-file|--log-file)
+      COMPREPLY=($(compgen -f -- "$cur"))
+      return
+      ;;
+    --swupd-cert|--swupd-state)
+      COMPREPLY=($(compgen -d -- "$cur"))
+      return
+      ;;
+    --swupd-contenturl|--swupd-mirror|--swupd-versionurl|--telemetry-url)
+      # a zero-width space before `h`, and at the last character
+      opts='​https://...  '
+      COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+      return
+      ;;
+    --log-level)
+      # shellcheck disable=1018
+      case "$2" in
+        ​e*)
+          opts="1"
+          COMPREPLY=($(compgen -W "$opts" -- "$opts"))
+          ;;
+        ​w*)
+          opts="2"
+          COMPREPLY=($(compgen -W "$opts" -- "$opts"))
+          ;;
+        ​i*)
+          opts="3"
+          COMPREPLY=($(compgen -W "$opts" -- "$opts"))
+          ;;
+        ​d*)
+          opts="4"
+          COMPREPLY=($(compgen -W "$opts" -- "$opts"))
+          ;;
+        *)
+          # a zero-width space before each alternative
+          opts="​error-->1 ​warning-->2 ​info-->3 ​debug--->4"
+          COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+          ;;
+      esac
+      return
+      ;;
+    --help|--version)
+      return
+      ;;
+  esac
+
+  if [[ $cur == -* ]]; then
+    # shellcheck disable=SC2016
+    COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    # shellcheck disable=SC2128
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+  fi
+}
+
+complete -o nosort -F _clr_installer clr-installer
+complete -o nosort -F _clr_installer clr-installer-gui

--- a/completions/zsh/_clr-installer
+++ b/completions/zsh/_clr-installer
@@ -26,45 +26,57 @@ local -A opt_args val_args
 local -a global_opts; global_opts=(
   '(-)'{-v,--version}'[Version of the Installer]'
   '(-)--system-check[Verify current system is compatible with Clear Linux and exit]'
+  '--allow-insecure-http[Allow installation over insecure connections]'
   '--archive[Archive data to target after finishing]:archive:((
              true\:Archive\ data.\ \(default\)
-             false\:Don`t\archive\ data.))'
+             false\:Don\`t\ archive\ data.))'
   '(-b --block-device)'{-b,--block-device}'[Adds a new block-device`s entry to configuration file. Format: <alias:filename>]:block-device: _clr_installer_block_device'
+  '(-B --bundles)'{-B,--bundles}'[Comma-separated list of bundles to install]:bundles: _message -r "FOO,BAR,..."'
+  '--cfPurge[Remove ConfigFile after finishing]'
   '(-c --config)'{-c,--config}'[Installation configuration file]:config file: _files -g \*.yaml'
   '--copy-network[Copy the network interface configuration files to target]:copy network:((
                   true\:Copy\ the\ network\ interface\ configuration\ files\ to\ target\ \(default\)
-                  false\:Don`t\ copy\ the\ network\ interface\ configuration\ files\ to\ target))'
-  '--crypt-file[File containing the cryptsetup password]:crypt file: _files'
+                  false\:Don\`t\ copy\ the\ network\ interface\ configuration\ files\ to\ target))'
+  '--copy-swupd[Copy /etc/swupd configuration files to target]:copy swupd:((
+                true\:Copy\ the\ /etc/swupd\ configuration\ \(default\)
+                flase\:Don\`t\ copy\ the\ /etc/swupd\ configuration))'
+  '--crypt-file[File containing the cryptsetup password]:crypt file: _files -g \*.pem'
   '--genpass[Generates a PAM compatible password hash based on the provided salt string]:salt string:()'
   '--iso[Generate Hybrid ISO image (Legacy/UEFI bootable)]'
   '(-j --json-yaml)'{-j,--json-yaml}'[Converts ister JSON config to clr-installer YAML config]:convert config file: _files -g \*.json'
   '--keep-image[Keep the generated image file (when creating ISO)]:keep-image:((
                 true\:Keep\ the\ generated\ image\ file\ \(default\)
-                false\:Don`t\ keep\ generated\ image\ file))'
+                false\:Don\`t\ keep\ generated\ image\ file))'
   '--log-file[The log file path (default \"$HOME/clr-installer.log\")]:log file: _files'
   '(-l --log-level)'{-l,--log-level}'[Set log level]:log level:((
                                       4\:debug\ \(default\)
                                       3\:info
                                       2\:warning
                                       1\:error))'
-  '--reboot[Reboot after finishing (default true)]:reboot:((
+  '--reboot[Reboot after finishing]:reboot:((
                true\:Reboot\ after\ finishing\ \(default\)
-               false\:Don`t\ reboot\ after\ finishing))'
+               false\:Don\`t\ reboot\ after\ finishing))'
+  '--skip-validation-size[Skip the partition validation size check]'
   '(-S --stub-image)'{-S,--stub-image}'[Creates the filesystems only - dont perform an actual install]'
+  '--swap-file-size[Size of the swapfile]:swapfile size: _message -r "<size>[B|K|M|G]"'
   '--swupd-cert[Specify alternative path to swupd certificates]:swupd certification path: _files -/'
   '--swupd-clean[Clean Swupd state-dir content after install]'
   '--swupd-contenturl[RFC-3986 encoded url for content file downloads]:content url: _urls -i https\://'
-  '--swupd-format[The format suffix for version file downloads]:format: _message -r \"staging,1,2,etc\"'
-  '--swupd-mirror[RFC-3986 encoded url for version string and content file downloads]:swupd mirror url: _urls -i https\://'
+  '--swupd-format[The format suffix for version file downloads]:format: _message -r "staging,1,2,etc"'
+  '(--swupd-url)--swupd-mirror[RFC-3986 encoded url for version string and content file downloads]:swupd mirror url: _urls -i https\://'
   '--swupd-skip-diskspace-check[Do not check free disk space before adding bundle]:swupd skip diskspace check:((
-                                true\:Do\ not\ check\ free\ disk\ space\ \(default\)
+                                true\:Don\`t\ check\ free\ disk\ space\ \(default\)
                                 false\:Check\ free\ disk\ space))'
+  '--swupd-skip-optional[Do not install optional bundles (also-add flag in Manifests)]'
   '--swupd-state[Specify alternative swupd state directory]:swupd state dir: _files -/'
+  '(--swupd-contenturl --swupd-mirror --swupd-version-url)--swupd-url[RFC-3986 encoded url for version string and content file downloads]:swupd url: _urls -i https\://'
+  '--swupd-version[Update to version V, also accepts "latest" (default)]:version:()'
   '--swupd-versionurl[RFC-3986 encoded url for version file downloads]:swupd version url: _urls -i https\://'
   '--telemetry[Enable Telemetry]:telemetry: _clr_installer_telemetry'
   '--telemetry-policy[Telemetry Policy text]:telemetry-policy:()'
   '--telemetry-tid[Telemetry server TID]:telemetry-tid:()'
   '--telemetry-url[Telemetry server URL]:telemetry-url: _urls -i https\://'
+  '(-T --template)'{-T,--template=}'[Generates a template clr-installer YAML config file]'
   '--tui[Force to use TUI frontend]'
 )
 

--- a/completions/zsh/_clr-installer
+++ b/completions/zsh/_clr-installer
@@ -1,0 +1,98 @@
+#compdef clr-installer clr-installer-gui
+# -----------------------------------------------------------------------
+#   Clear Linux OS* Installer - autocompletion script
+#
+#   Author: Lucius Hu - http://github.com/lebensterben
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, version 2 or later of the License.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------
+
+# Variables required by zsh completion system
+local variant context curcontext="$curcontext" ret=1
+local -a line state state_descr
+local -A opt_args val_args
+
+# Options
+local -a global_opts; global_opts=(
+  '(-)'{-v,--version}'[Version of the Installer]'
+  '(-)--system-check[Verify current system is compatible with Clear Linux and exit]'
+  '--archive[Archive data to target after finishing]:archive:((
+             true\:Archive\ data.\ \(default\)
+             false\:Don`t\archive\ data.))'
+  '(-b --block-device)'{-b,--block-device}'[Adds a new block-device`s entry to configuration file. Format: <alias:filename>]:block-device: _clr_installer_block_device'
+  '(-c --config)'{-c,--config}'[Installation configuration file]:config file: _files -g \*.yaml'
+  '--copy-network[Copy the network interface configuration files to target]:copy network:((
+                  true\:Copy\ the\ network\ interface\ configuration\ files\ to\ target\ \(default\)
+                  false\:Don`t\ copy\ the\ network\ interface\ configuration\ files\ to\ target))'
+  '--crypt-file[File containing the cryptsetup password]:crypt file: _files'
+  '--genpass[Generates a PAM compatible password hash based on the provided salt string]:salt string:()'
+  '--iso[Generate Hybrid ISO image (Legacy/UEFI bootable)]'
+  '(-j --json-yaml)'{-j,--json-yaml}'[Converts ister JSON config to clr-installer YAML config]:convert config file: _files -g \*.json'
+  '--keep-image[Keep the generated image file (when creating ISO)]:keep-image:((
+                true\:Keep\ the\ generated\ image\ file\ \(default\)
+                false\:Don`t\ keep\ generated\ image\ file))'
+  '--log-file[The log file path (default \"$HOME/clr-installer.log\")]:log file: _files'
+  '(-l --log-level)'{-l,--log-level}'[Set log level]:log level:((
+                                      4\:debug\ \(default\)
+                                      3\:info
+                                      2\:warning
+                                      1\:error))'
+  '--reboot[Reboot after finishing (default true)]:reboot:((
+               true\:Reboot\ after\ finishing\ \(default\)
+               false\:Don`t\ reboot\ after\ finishing))'
+  '(-S --stub-image)'{-S,--stub-image}'[Creates the filesystems only - dont perform an actual install]'
+  '--swupd-cert[Specify alternative path to swupd certificates]:swupd certification path: _files -/'
+  '--swupd-clean[Clean Swupd state-dir content after install]'
+  '--swupd-contenturl[RFC-3986 encoded url for content file downloads]:content url: _urls -i https\://'
+  '--swupd-format[The format suffix for version file downloads]:format: _message -r \"staging,1,2,etc\"'
+  '--swupd-mirror[RFC-3986 encoded url for version string and content file downloads]:swupd mirror url: _urls -i https\://'
+  '--swupd-skip-diskspace-check[Do not check free disk space before adding bundle]:swupd skip diskspace check:((
+                                true\:Do\ not\ check\ free\ disk\ space\ \(default\)
+                                false\:Check\ free\ disk\ space))'
+  '--swupd-state[Specify alternative swupd state directory]:swupd state dir: _files -/'
+  '--swupd-versionurl[RFC-3986 encoded url for version file downloads]:swupd version url: _urls -i https\://'
+  '--telemetry[Enable Telemetry]:telemetry: _clr_installer_telemetry'
+  '--telemetry-policy[Telemetry Policy text]:telemetry-policy:()'
+  '--telemetry-tid[Telemetry server TID]:telemetry-tid:()'
+  '--telemetry-url[Telemetry server URL]:telemetry-url: _urls -i https\://'
+  '--tui[Force to use TUI frontend]'
+)
+
+# Display valid argument format to `-b|--block-device` flag
+(( $+functions[_clr_installer_block_device] )) ||
+  _clr_installer_block_device () {
+    local -a blockdevice=($(lsblk --noheadings --raw --paths | cut -d' ' -f1))
+    if [ -z $words[-1] ] || [[ ${words[-1]##*,} != *\:* ]]; then
+      _message -r 'Format: alias1:filename1[,alias2:filename2,...]'
+    else
+      compset -P '*:'
+    _alternative 'blockdevice:blockdevice: _values -s , -S : \
+                  $blockdevice'
+    fi
+  }
+
+# Remind user to specify --telemetry-url and --telemetry-tid
+(( $+functions[_clr_installer_telemetry] )) ||
+  _clr_installer_telemetry () {
+    if [[ $words == *--telemetry-url* ]] && [[ $words == *--telemetry-tid* ]]; then
+      _alternatives 'telemetry:telemetry:((true\:Enable\ Telemetry
+                                           flase\:Disable\ Telemetry))'
+    else
+      _message -r 'Please specify --telemetry-url and --telemetry-tid first'
+    fi
+  }
+
+# Level-1 completion for sub-command and options to swupd
+_arguments $global_opts && ret=0
+
+return $ret


### PR DESCRIPTION
- Added `zsh` completion script at `completions/zsh/_clr-installer`. It's
  suggested to install it at
  `/usr/share/zsh/site-functions/_clr-installer`.
- Added `bash` completion script at `completions/bash/clr-installer`. It's
  suggested to install it at
  `/usr/share/bash-completion/completions/clr-installer`

Fixes Issue: #711 

---

## Notes on Bash autocompletion script

I invented some tricks with unicode non-printable characters to provide additional functionality not supported by bash builtin completion system:

- line 32-42, will show a help message about the format of the argument to
  `--block-device` option, as 
   >Format:"alias1:filename1[,alias2:filename2,...]" BlockDevices:${blockdevice:0:-1}"
  where `$blockdevice` are generated dynamically. This message won't be
  completed.
- line 62-64, will remind the user to use `https://` urls. This message won't be
  completed as well.
- line 68-91, will first show a help message on the definition of log-levels,
  >error-->1 warning-->2 info-->3 debug--->4
  When the user type any of `e`, `w`, `i`, or `d`, and then press `<TAB>` it
  would be replaced by the integer value accordingly. When the user type any
  other character, the message persists.

The drawback of this trick is, those unicode characters would be rendered as a solid rectangle in some terminals, such as tty.

If this is not acceptable, just remove the aforementioned lines.