### PR TITLE
improvement(utils/copyfile): changed writeFile to io.Copy

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -114,7 +114,7 @@ func CopyFile(src string, dest string) error {
 	destDir := filepath.Dir(dest)
 	if _, err := os.Stat(destDir); err != nil {
 		if os.IsNotExist(err) {
-			return errors.Errorf("no such dest directory: %s", destDir)
+			return errors.Errorf("No such dest directory: %s", destDir)
 		}
 		return errors.Wrap(err)
 	}
@@ -122,7 +122,7 @@ func CopyFile(src string, dest string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errors.Errorf("no such file: %s", src)
+			return errors.Errorf("No such file: %s", src)
 		}
 		return errors.Wrap(err)
 	}


### PR DESCRIPTION
io.Copy uses a buffer (32 KB), there is no need to read the entire file and allocate large amounts
of memory.

It works faster.
![image](https://user-images.githubusercontent.com/31652715/81217912-8e03b580-9007-11ea-8fe2-a3144fa31a50.png)
benchmark is available here: [gist](https://gist.github.com/Lasiar/2a4f2f599f9d18f8684e7badbbba110e).

Changes proposed in this pull request:
- Changed WriteFile to io.Copy with default size buffer
- Added file.Sync() to ensure file content is written to disk.

