### PR TITLE
Fix Auto update Bug

### DIFF
--- a/boolset/boolset.go
+++ b/boolset/boolset.go
@@ -1,0 +1,98 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package boolset
+
+// BoolSet used to track if both a boolean's value
+// and if it was explicitly set.
+// Useful for items which default to True
+type BoolSet struct {
+	value    bool
+	defValue bool
+	set      bool
+}
+
+// New creates a new instance of BoolSet
+func New() *BoolSet {
+	return &BoolSet{}
+}
+
+// New creates a new instance of BoolSet
+// with the value and default set to 'true'
+func NewTrue() *BoolSet {
+	return &BoolSet{value: true, defValue: true}
+}
+
+// Value returns the state Value
+func (bs *BoolSet) Value() bool {
+	return bs.value
+}
+
+// SetValue sets the Value passed and sets the Set value state
+func (bs *BoolSet) SetValue(value bool) {
+	bs.value = value
+	bs.set = true
+}
+
+// Value returns the default state Value
+func (bs *BoolSet) Default() bool {
+	return bs.defValue
+}
+
+// SetDefault sets the Default Value passed
+func (bs *BoolSet) SetDefault(value bool) {
+	bs.defValue = value
+}
+
+// ClearSet sets the Value passed and clears the Set value state
+func (bs *BoolSet) ClearSet() {
+	bs.set = false
+}
+
+// ClearSetDefault sets the Default Value passed and clears the Set value state
+func (bs *BoolSet) ClearSetDefault(value bool) {
+	bs.defValue = value
+	bs.set = false
+}
+
+// IsSet returns if we have explicitly set a value
+func (bs *BoolSet) IsSet() bool {
+	return bs.set
+}
+
+// IsDefault returns if Value is set to the current Default
+func (bs *BoolSet) IsDefault() bool {
+	return bs.value == bs.defValue
+}
+
+// MarshalYAML is the yaml Marshaller implementation
+func (bs *BoolSet) MarshalYAML() (interface{}, error) {
+	return bs.Value(), nil
+}
+
+// UnmarshalYAML is the yaml Unmarshaller for BoolSet
+func (bs *BoolSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	if bs == nil {
+		bs = New()
+	}
+
+	var boolValue bool
+
+	if err := unmarshal(&boolValue); err != nil {
+		return err
+	}
+
+	// Copy the unmarshaled data
+	bs.SetValue(boolValue)
+
+	return nil
+}
+
+// IsZero is the yaml check for zero value
+func (bs *BoolSet) IsZero() bool {
+	if bs.IsSet() {
+		return false
+	}
+	return bs.IsDefault()
+}

--- a/boolset/boolset_test.go
+++ b/boolset/boolset_test.go
@@ -1,0 +1,246 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+package boolset
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestSetValue(t *testing.T) {
+	truth := New()
+
+	// Should default to false, like a boolean
+	if truth.Value() {
+		t.Fatalf("Should have defaulted to false")
+	}
+
+	if truth.Default() != false {
+		t.Fatalf("Should have default set to false")
+	}
+
+	// It should not be set by default
+	if truth.IsSet() {
+		t.Fatalf("Should not be set when only declared")
+	}
+
+	truth.SetValue(true)
+
+	if !truth.IsSet() {
+		t.Fatalf("Should be set from the previous assignment")
+	}
+
+	if !truth.Value() {
+		t.Fatalf("Should have been set to true")
+	}
+}
+
+func TestSetDefaultValue(t *testing.T) {
+	truth := NewTrue()
+
+	if !truth.Value() {
+		t.Fatalf("Should have been set to true")
+	}
+
+	if truth.Default() != true {
+		t.Fatalf("Should have default set to true")
+	}
+
+	if truth.IsSet() {
+		t.Fatalf("Should not be set from the SetDefault")
+	}
+
+	if !truth.IsDefault() {
+		t.Fatalf("Should be set to Default from the previous assignment")
+	}
+
+	truth.SetValue(true)
+
+	if !truth.IsSet() {
+		t.Fatalf("Should be set from the SetValue")
+	}
+
+	if !truth.IsDefault() {
+		t.Fatalf("Should be set to Default from the previous assignment")
+	}
+
+	truth.SetDefault(false)
+	truth.SetValue(true)
+
+	if !truth.IsSet() {
+		t.Fatalf("Should be set from the SetValue")
+	}
+
+	if truth.IsDefault() {
+		t.Fatalf("Should NOT be set to Default from the SetDefault()")
+	}
+}
+
+func TestSetDefaultFalseValue(t *testing.T) {
+	truth := &BoolSet{}
+
+	if truth.Value() {
+		t.Fatalf("Should have been set to false")
+	}
+
+	if truth.Default() != false {
+		t.Fatalf("Should have default set to false")
+	}
+
+	if truth.IsSet() {
+		t.Fatalf("Should not be set from the declaration")
+	}
+
+	if !truth.IsDefault() {
+		t.Fatalf("Should be set to Default from the declaration")
+	}
+
+	truth.SetValue(false)
+
+	if !truth.IsSet() {
+		t.Fatalf("Should be set from the SetValue")
+	}
+
+	if !truth.IsDefault() {
+		t.Fatalf("Should be set to Default from the previous assignment")
+	}
+}
+
+func TestCheckSet(t *testing.T) {
+	truth := NewTrue()
+
+	if truth.IsSet() {
+		t.Fatalf("Should not be set from the NewTrue")
+	}
+
+	truth.SetValue(true)
+
+	if !truth.IsSet() {
+		t.Fatalf("Should be set from the SetValue")
+	}
+
+	truth.ClearSet()
+	if truth.Value() != true {
+		t.Fatalf("Should be set to true after ClearSet")
+	}
+	if truth.IsSet() {
+		t.Fatalf("Should NOT be set from the ClearSet")
+	}
+
+	truth.SetValue(false)
+
+	if truth.IsDefault() {
+		t.Fatalf("Should NOT be set to default from SetValue(false) and NewTrue()")
+	}
+
+	if !truth.IsSet() {
+		t.Fatalf("Should be set from the SetValue")
+	}
+
+	truth.ClearSetDefault(false)
+	if truth.Value() != false {
+		t.Fatalf("Should be set to true after ClearSetDefault")
+	}
+	if truth.IsSet() {
+		t.Fatalf("Should NOT be set from the ClearSet")
+	}
+
+	if !truth.IsDefault() {
+		t.Fatalf("Should be set to default from SetValue(false) and ClearSetDefault(false)")
+	}
+}
+
+type SystemInstall struct {
+	PostArchive *BoolSet `yaml:"postArchive,omitempty,flow"`
+	Hostname    string   `yaml:"hostname,omitempty,flow"`
+	AutoUpdate  *BoolSet `yaml:"autoUpdate,flow"`
+}
+
+func TestMarshalTrue(t *testing.T) {
+	// Log a sanitized YAML file with Telemetry
+	var copyTruth SystemInstall
+	bothTrue := &SystemInstall{Hostname: "both-true"}
+	bothTrue.AutoUpdate = NewTrue()
+	bothTrue.PostArchive = NewTrue()
+
+	// Marshal current into bytes
+	confBytes, bytesErr := yaml.Marshal(bothTrue)
+	if bytesErr != nil {
+		t.Fatalf("Failed to Marshal YAML: %v", bytesErr)
+	}
+
+	t.Logf("bytes:\n%+v\n", string(confBytes))
+
+	// Unmarshal into a copy
+	if yamlErr := yaml.Unmarshal(confBytes, &copyTruth); yamlErr != nil {
+		t.Fatalf("Failed to Unmarshal YAML: %v", yamlErr)
+	}
+
+	if copyTruth.AutoUpdate == nil {
+		t.Fatalf("No AutoUpdate, but should have unmarshal")
+	}
+
+	if bothTrue.AutoUpdate.Default() == copyTruth.AutoUpdate.Default() {
+		t.Fatalf("Default should not have been passed via Marshal/Unmarshal")
+	}
+
+	if bothTrue.AutoUpdate.Value() != copyTruth.AutoUpdate.Value() {
+		t.Fatalf("Value should have been passed via Marshal/Unmarshal: %v != %v",
+			bothTrue.AutoUpdate.Value(), copyTruth.AutoUpdate.Value())
+	}
+
+	if copyTruth.PostArchive != nil {
+		t.Fatalf("Found PostArchive, but should not have unmarshal")
+	}
+}
+
+func TestMarshalFalse(t *testing.T) {
+	// Log a sanitized YAML file with Telemetry
+	var copyTruth SystemInstall
+	bothFalse := &SystemInstall{Hostname: "both-false"}
+	bothFalse.AutoUpdate = New()
+	bothFalse.PostArchive = New()
+	bothFalse.PostArchive.SetValue(false)
+
+	// Marshal current into bytes
+	confBytes, bytesErr := yaml.Marshal(bothFalse)
+	if bytesErr != nil {
+		t.Fatalf("Failed to Marshal YAML: %v", bytesErr)
+	}
+
+	t.Logf("bytes:\n%+v\n", string(confBytes))
+
+	// Unmarshal into a copy
+	if yamlErr := yaml.Unmarshal(confBytes, &copyTruth); yamlErr != nil {
+		t.Fatalf("Failed to Unmarshal YAML: %v", yamlErr)
+	}
+
+	if copyTruth.AutoUpdate == nil {
+		t.Fatalf("No AutoUpdate, but should have unmarshal")
+	}
+
+	if bothFalse.AutoUpdate.Default() != copyTruth.AutoUpdate.Default() {
+		t.Fatalf("Default should have been passed via Marshal/Unmarshal")
+	}
+
+	if bothFalse.AutoUpdate.Value() != copyTruth.AutoUpdate.Value() {
+		t.Fatalf("Value should have been passed via Marshal/Unmarshal: %v != %v",
+			bothFalse.AutoUpdate.Value(), copyTruth.AutoUpdate.Value())
+	}
+
+	if copyTruth.PostArchive == nil {
+		t.Fatalf("No PostArchive, but should have unmarshal")
+	}
+
+	if bothFalse.PostArchive.Default() != copyTruth.PostArchive.Default() {
+		t.Fatalf("Default should have been passed via Marshal/Unmarshal")
+	}
+
+	if bothFalse.PostArchive.Value() != copyTruth.PostArchive.Value() {
+		t.Fatalf("Value should have been passed via Marshal/Unmarshal: %v != %v",
+			bothFalse.PostArchive.Value(), copyTruth.PostArchive.Value())
+	}
+}

--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -451,7 +451,7 @@ func processOptionsSaveIfSet(options args.Args, md *model.SystemInstall) {
 	}
 
 	if options.ArchiveSet {
-		md.PostArchive = options.Archive
+		md.PostArchive.SetValue(options.Archive)
 	}
 
 	if options.SkipValidationSizeSet {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/clearlinux/clr-installer/args"
+	"github.com/clearlinux/clr-installer/boolset"
 	"github.com/clearlinux/clr-installer/cmd"
 	"github.com/clearlinux/clr-installer/conf"
 	"github.com/clearlinux/clr-installer/errors"
@@ -654,7 +655,7 @@ func contentInstall(rootDir string, version string,
 		}
 	}
 
-	if !md.AutoUpdate {
+	if !md.AutoUpdate.Value() {
 		msg := utils.Locale.Get("Disabling automatic updates")
 		prg = progress.NewLoop(msg)
 		log.Info(msg)
@@ -1030,13 +1031,14 @@ func writeCustomConfig(chrootPath string, md *model.SystemInstall) error {
 
 	// Create basic config based on provided values
 	customModel := &model.SystemInstall{
-		Bundles:    md.TargetBundles,
-		Keyboard:   md.Keyboard,
-		Language:   md.Language,
-		Timezone:   md.Timezone,
-		Kernel:     md.Kernel,
-		AutoUpdate: true, // We should always default to enabled
+		Bundles:  md.TargetBundles,
+		Keyboard: md.Keyboard,
+		Language: md.Language,
+		Timezone: md.Timezone,
+		Kernel:   md.Kernel,
 	}
+	// We should always default to enabled
+	customModel.AutoUpdate = boolset.NewTrue()
 
 	return customModel.WriteFile(path.Join(customPath, conf.ConfigFile))
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -938,7 +938,7 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 		log.Error("Failed to log Telemetry success record")
 	}
 
-	if md.PostArchive {
+	if md.PostArchive.Value() {
 		log.Info("Saving Installation results to %s", rootDir)
 
 		saveDir := filepath.Join(rootDir, "root")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -105,7 +105,7 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		version = fmt.Sprintf("%d", model.Version)
 	}
 
-	log.Debug("Clear Linux version: %s", version)
+	log.Debug("Clear Linux OS version: %s", version)
 
 	// do we have the minimum required to install a system?
 	if err = model.Validate(); err != nil {
@@ -576,19 +576,19 @@ func contentInstall(rootDir string, version string,
 		if err := utils.ParseOSClearVersion(); err != nil {
 			return prg, err
 		}
-		log.Info("Overriding version from %s to %s to enable offline install", version, utils.ClearVersion)
-		version = utils.ClearVersion
 
-		// Copying offline content here is a performance optimization and is not a hard
-		// failure because Swupd may be able to successfully copy offline content or
-		// install over the network.
-		if err := copyOfflineToStatedir(rootDir, sw.GetStateDir()); err != nil {
-			log.Warning("Failed to copy offline content: %s", err)
+		if version == "latest" || version == utils.ClearVersion {
+			// Copying offline content here is a performance optimization and is not a hard
+			// failure because Swupd may be able to successfully copy offline content or
+			// install over the network.
+			if err := copyOfflineToStatedir(rootDir, sw.GetStateDir()); err != nil {
+				log.Warning("Failed to copy offline content: %s", err)
+			}
+		} else {
+			log.Warning("Ignoring the Offline content (%s) due to version set to %s", utils.ClearVersion, version)
 		}
 
 		prg.Success()
-	} else if md.AutoUpdate {
-		version = "latest"
 	}
 
 	msg := utils.Locale.Get("Installing base OS and configured bundles")

--- a/gui/pages/swupd_config.go
+++ b/gui/pages/swupd_config.go
@@ -162,7 +162,7 @@ func NewSwupdConfigPage(controller Controller, model *model.SystemInstall) (Page
 	}
 
 	var warning, style string
-	if page.model.AutoUpdate {
+	if page.model.AutoUpdate.Value() {
 		style = ""
 		warning = ""
 	} else {
@@ -290,20 +290,20 @@ func (page *SwupdConfigPage) GetTitle() string {
 // StoreChanges will store this pages changes into the model
 func (page *SwupdConfigPage) StoreChanges() {
 	page.validateMirror()
-	page.model.AutoUpdate = page.autoUpdateButton.GetActive()
+	page.model.AutoUpdate.SetValue(page.autoUpdateButton.GetActive())
 }
 
 // ResetChanges will reset this page to match the model
 func (page *SwupdConfigPage) ResetChanges() {
 	page.controller.SetButtonState(ButtonConfirm, true)
 	setTextInEntry(page.mirrorEntry, page.model.SwupdMirror)
-	page.autoUpdateButton.SetActive(page.model.AutoUpdate)
+	page.autoUpdateButton.SetActive(page.model.AutoUpdate.Value())
 }
 
 // GetConfiguredValue returns a string representation of the current config
 func (page *SwupdConfigPage) GetConfiguredValue() string {
 	var ret string
-	if page.model.AutoUpdate {
+	if page.model.AutoUpdate.Value() {
 		ret = utils.Locale.Get("Auto updates enabled")
 	} else {
 		ret = utils.Locale.Get("Auto updates disabled")

--- a/massinstall/massinstall.go
+++ b/massinstall/massinstall.go
@@ -216,8 +216,8 @@ func (mi *MassInstall) Run(md *model.SystemInstall, rootDir string, options args
 
 	log.Debug("Starting install")
 
-	if md.Version > 0 {
-		fmt.Println("Config file specifies a target \"version\", forcing auto-update off.")
+	if !md.AutoUpdate.Value() {
+		fmt.Println("Swupd auto-update set to off!")
 	}
 
 	instError = controller.Install(rootDir, md, options)

--- a/model/model.go
+++ b/model/model.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/clearlinux/clr-installer/args"
+	"github.com/clearlinux/clr-installer/boolset"
 	"github.com/clearlinux/clr-installer/errors"
 	"github.com/clearlinux/clr-installer/kernel"
 	"github.com/clearlinux/clr-installer/keyboard"
@@ -70,7 +71,7 @@ type SystemInstall struct {
 	SwupdSkipOptional bool                             `yaml:"swupdSkipOptional,omitempty,flow"`
 	PostArchive       bool                             `yaml:"postArchive,omitempty,flow"`
 	Hostname          string                           `yaml:"hostname,omitempty,flow"`
-	AutoUpdate        bool                             `yaml:"autoUpdate,flow"`
+	AutoUpdate        *boolset.BoolSet                 `yaml:"autoUpdate,flow"`
 	TelemetryURL      string                           `yaml:"telemetryURL,omitempty,flow"`
 	TelemetryTID      string                           `yaml:"telemetryTID,omitempty,flow"`
 	TelemetryPolicy   string                           `yaml:"telemetryPolicy,omitempty,flow"`
@@ -417,9 +418,6 @@ func LoadFile(path string, options args.Args) (*SystemInstall, error) {
 	// Default to archiving by default
 	result.PostArchive = true
 
-	// Default to Auto Updating enabled by default
-	result.AutoUpdate = true
-
 	if _, err := os.Stat(path); err == nil {
 		configStr, err := ioutil.ReadFile(path)
 		if err != nil {
@@ -430,6 +428,13 @@ func LoadFile(path string, options args.Args) (*SystemInstall, error) {
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}
+	}
+
+	// Default to Auto Updating enabled by default
+	if result.AutoUpdate == nil {
+		result.AutoUpdate = boolset.NewTrue()
+	} else {
+		result.AutoUpdate.SetDefault(true)
 	}
 
 	// Set default Timezone if not defined
@@ -518,10 +523,6 @@ func LoadFile(path string, options args.Args) (*SystemInstall, error) {
 
 	if result.MediaOpts.SwapFileSize != "" {
 		result.MediaOpts.SwapFileSet = true
-	}
-
-	if result.Version > 0 {
-		result.AutoUpdate = false
 	}
 
 	return &result, nil

--- a/model/model.go
+++ b/model/model.go
@@ -69,7 +69,7 @@ type SystemInstall struct {
 	SwupdMirror       string                           `yaml:"swupdMirror,omitempty,flow"`
 	AllowInsecureHTTP bool                             `yaml:"AllowInsecureHTTP,omitempty,flow"`
 	SwupdSkipOptional bool                             `yaml:"swupdSkipOptional,omitempty,flow"`
-	PostArchive       bool                             `yaml:"postArchive,omitempty,flow"`
+	PostArchive       *boolset.BoolSet                 `yaml:"postArchive,omitempty,flow"`
 	Hostname          string                           `yaml:"hostname,omitempty,flow"`
 	AutoUpdate        *boolset.BoolSet                 `yaml:"autoUpdate,flow"`
 	TelemetryURL      string                           `yaml:"telemetryURL,omitempty,flow"`
@@ -415,9 +415,6 @@ func (si *SystemInstall) AddNetworkInterface(iface *network.Interface) {
 func LoadFile(path string, options args.Args) (*SystemInstall, error) {
 	var result SystemInstall
 
-	// Default to archiving by default
-	result.PostArchive = true
-
 	if _, err := os.Stat(path); err == nil {
 		configStr, err := ioutil.ReadFile(path)
 		if err != nil {
@@ -428,6 +425,13 @@ func LoadFile(path string, options args.Args) (*SystemInstall, error) {
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}
+	}
+
+	// Default to archiving by default
+	if result.PostArchive == nil {
+		result.PostArchive = boolset.NewTrue()
+	} else {
+		result.PostArchive.SetDefault(true)
 	}
 
 	// Default to Auto Updating enabled by default

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -99,6 +99,7 @@ func TestLoadFile(t *testing.T) {
 
 	for _, curr := range tests {
 		path := filepath.Join(testsDir, curr.file)
+		t.Logf("Loading test file %v", curr)
 		if filepath.Ext(curr.file) == ".json" {
 			md, err := JSONtoYAMLConfig(path)
 			if err == nil {

--- a/tests/coverage-curr-status
+++ b/tests/coverage-curr-status
@@ -1,4 +1,5 @@
 ok  	github.com/clearlinux/clr-installer/args	0.272s	coverage: 85.6% of statements
+ok  	github.com/clearlinux/clr-installer/boolset	0.014s	coverage: 91.3% of statements
 ?   	github.com/clearlinux/clr-installer/clr-installer	[no test files]
 ok  	github.com/clearlinux/clr-installer/cmd	0.012s	coverage: 0.0% of statements
 ?   	github.com/clearlinux/clr-installer/conf	[no test files]

--- a/tui/autoupdate.go
+++ b/tui/autoupdate.go
@@ -16,7 +16,7 @@ type AutoUpdatePage struct {
 
 // GetConfiguredValue Returns the string representation of currently value set
 func (aup *AutoUpdatePage) GetConfiguredValue() string {
-	if aup.getModel().AutoUpdate {
+	if aup.getModel().AutoUpdate.Value() {
 		return "Enabled"
 	}
 	return "Disabled"
@@ -57,9 +57,9 @@ func (aup *AutoUpdatePage) DeActivate() {
 	model := aup.getModel()
 
 	if aup.action == ActionConfirmButton {
-		model.AutoUpdate = true
+		model.AutoUpdate.SetValue(true)
 	} else if aup.action == ActionBackButton {
-		model.AutoUpdate = false
+		model.AutoUpdate.SetValue(false)
 	}
 }
 
@@ -67,7 +67,7 @@ func (aup *AutoUpdatePage) DeActivate() {
 // If Auto Update is enabled in the data model then the Confirm button will be active
 // otherwise the Back button will be activated.
 func (aup *AutoUpdatePage) Activate() {
-	if aup.getModel().AutoUpdate {
+	if aup.getModel().AutoUpdate.Value() {
 		aup.activated = aup.confirmBtn
 	} else {
 		aup.activated = aup.backBtn
@@ -77,7 +77,7 @@ func (aup *AutoUpdatePage) Activate() {
 // GetConfigDefinition returns if the config was interactively defined by the user,
 // was loaded from a config file or if the config is not set.
 func (aup *AutoUpdatePage) GetConfigDefinition() int {
-	if aup.getModel().AutoUpdate {
+	if aup.getModel().AutoUpdate.Value() {
 		return ConfigDefinedByConfig
 	}
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a new type for booleans which should default to true
- Updated the auto-update code
  - Auto Update is Disabled when: `autoAupdate: false` in the YAML or if the `version` or `--swupd-version` is set to a value other than `0` or `<current OS version>`
  - Auto Update is Enabled by default, or when `autoAupdate: true` set in the YAML regardless of version setting




