### PR TITLE
Fix case of allowInsecureHTTP for YAML config

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -67,7 +67,7 @@ type SystemInstall struct {
 	Kernel            *kernel.Kernel                   `yaml:"kernel,omitempty,flow"`
 	PostReboot        bool                             `yaml:"postReboot,omitempty,flow"`
 	SwupdMirror       string                           `yaml:"swupdMirror,omitempty,flow"`
-	AllowInsecureHTTP bool                             `yaml:"AllowInsecureHTTP,omitempty,flow"`
+	AllowInsecureHTTP bool                             `yaml:"allowInsecureHTTP,omitempty,flow"`
 	SwupdSkipOptional bool                             `yaml:"swupdSkipOptional,omitempty,flow"`
 	PostArchive       *boolset.BoolSet                 `yaml:"postArchive,omitempty,flow"`
 	Hostname          string                           `yaml:"hostname,omitempty,flow"`

--- a/scripts/InstallerYAMLSyntax.md
+++ b/scripts/InstallerYAMLSyntax.md
@@ -148,7 +148,7 @@ Item | Description | Default
 `swapFileSize:` | Size of the swapfile. If set to `0` no swapfile will be created. The suffixes `B` for bytes, `K` or `KB` for kilobytes, `M` or `MB` for megabytes, `G` or `GB` for gigabytes, `KiB` for kibibyte, `MiB` for mebibyte, `GiB` for gibibyte. | `-UNDEFINED-`
 `kernel` | Kernel bundle to be used | kernel-native
 `httpsProxy` | HTTPS Proxy as a string | `-UNDEFINED-`
-`allowInsecureHttp` | Allow installation and downloads over insecure connections | false
+`allowInsecureHTTP` | Allow installation and downloads over insecure connections | false
 `hostname` | Name of the host system | `-UNIQUE RANDOM-`
 `version` | Version of Clear Linux OS to install | `-LATEST_VERSION-`
 `copySwupd` | Copy /etc/swupd configuration files to target | false (true for user-interface installs)


### PR DESCRIPTION
Documentation and standard convention requires allowInsecureHTTP to be camel-case, but the code and documentation were both incorrect. 
Some users will need to update the YAML files if they already had the incorrect 'AllowInsecureHttp' which is now 'allowInsecureHTTP'.