### PR TITLE
yaml: switch to strict unmarshal

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -903,7 +903,7 @@ func saveInstallResults(rootDir string, md *model.SystemInstall) error {
 		errMsgs = append(errMsgs, "Failed to generate YAML file")
 	}
 	// Unmarshal into a copy
-	if yamlErr := yaml.Unmarshal(confBytes, &cleanModel); yamlErr != nil {
+	if yamlErr := yaml.UnmarshalStrict(confBytes, &cleanModel); yamlErr != nil {
 		errMsgs = append(errMsgs, "Failed to duplicate YAML file")
 	}
 	// Sanitize the config data to remove any potential

--- a/local-travis/local-travis.go
+++ b/local-travis/local-travis.go
@@ -273,7 +273,7 @@ func main() {
 		panic(err)
 	}
 
-	if yamlErr := yaml.Unmarshal(content, &cfg); yamlErr != nil {
+	if yamlErr := yaml.UnmarshalStrict(content, &cfg); yamlErr != nil {
 		panic(yamlErr)
 	}
 

--- a/model/model.go
+++ b/model/model.go
@@ -421,7 +421,7 @@ func LoadFile(path string, options args.Args) (*SystemInstall, error) {
 			return nil, errors.Wrap(err)
 		}
 
-		err = yaml.Unmarshal(configStr, &result)
+		err = yaml.UnmarshalStrict(configStr, &result)
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}
@@ -592,7 +592,7 @@ func (si *SystemInstall) WriteFile(path string) error {
 	}
 
 	// Unmarshal into a copy
-	if yamlErr := yaml.Unmarshal(confBytes, &copyModel); yamlErr != nil {
+	if yamlErr := yaml.UnmarshalStrict(confBytes, &copyModel); yamlErr != nil {
 		return errors.Wrap(bytesErr)
 	}
 
@@ -657,7 +657,7 @@ func (si *SystemInstall) WriteScrubModelTargetMedias() (string, error) {
 	}
 
 	// Unmarshal into a copy
-	if yamlErr := yaml.Unmarshal(confBytes, &cleanModel); yamlErr != nil {
+	if yamlErr := yaml.UnmarshalStrict(confBytes, &cleanModel); yamlErr != nil {
 		return "", errors.Wrap(bytesErr)
 	}
 

--- a/network/network.go
+++ b/network/network.go
@@ -822,7 +822,7 @@ func DownloadInstallerMessage(header string, installConf string) string {
 		return ""
 	}
 
-	if err := yaml.Unmarshal(configStr, &result); err != nil {
+	if err := yaml.UnmarshalStrict(configStr, &result); err != nil {
 		log.Debug("Failed to parse the %s YAML file: %s", header, err)
 		return ""
 	}

--- a/tests/baseline.yaml
+++ b/tests/baseline.yaml
@@ -24,13 +24,9 @@ targetMedia:
     size: "50M"
     type: part
   - name: ${baseimg}2
-    fstype: swap
-    size: "32M"
-    type: part
-  - name: ${baseimg}3
     fstype: ext4
     mountpoint: /
-    size: "1.5G"
+    size: "2.0G"
     type: part
 
 bundles: [os-core, os-core-update, NetworkManager,  vim]
@@ -48,11 +44,9 @@ kernel: kernel-native
 
 post-install: [
    {cmd: "/bin/ls ${chrootDir}/etc"},
-   {chroot:true, cmd: "/bin/ls /etc"},
+   {chroot: true, cmd: "/bin/ls /etc"},
 ]
 
 post-image: [
    {cmd: "xz -q -T0 --stdout ${imageFile} > ${imageFile}.xz"},
 ]
-
-version: 0

--- a/tests/image-generation.yaml
+++ b/tests/image-generation.yaml
@@ -49,7 +49,7 @@ kernel: kernel-native
 
 post-install: [
    {cmd: "/bin/ls ${chrootDir}/etc"},
-   {chroot:true, cmd: "/bin/ls /etc"},
+   {chroot: true, cmd: "/bin/ls /etc"},
 ]
 
 version: 0

--- a/tests/iso-bad.yaml
+++ b/tests/iso-bad.yaml
@@ -50,7 +50,7 @@ kernel: kernel-native
 
 post-install: [
    {cmd: "/bin/ls ${chrootDir}/etc"},
-   {chroot:true, cmd: "/bin/ls /etc"},
+   {chroot: true, cmd: "/bin/ls /etc"},
 ]
 
 version: 0

--- a/tests/iso-desktop.yaml
+++ b/tests/iso-desktop.yaml
@@ -49,7 +49,7 @@ kernel: kernel-native
 
 post-install: [
    {cmd: "/bin/ls ${chrootDir}/etc"},
-   {chroot:true, cmd: "/bin/ls /etc"},
+   {chroot: true, cmd: "/bin/ls /etc"},
 ]
 
 version: 0

--- a/tests/iso-good.yaml
+++ b/tests/iso-good.yaml
@@ -50,7 +50,7 @@ kernel: kernel-native
 
 post-install: [
    {cmd: "/bin/ls ${chrootDir}/etc"},
-   {chroot:true, cmd: "/bin/ls /etc"},
+   {chroot: true, cmd: "/bin/ls /etc"},
 ]
 
 version: 0


### PR DESCRIPTION
Changes proposed in this pull request:
- Enable Strict Unmarshal to ensure that we fail on unknown tokens and duplicate tokens.


