### PR TITLE
storage: Fix legacy mode mkfs bug

### DIFF
--- a/storage/block_devices_ops.go
+++ b/storage/block_devices_ops.go
@@ -2749,7 +2749,13 @@ func setBootPartition(medias []*BlockDevice, mediaOpts MediaOpts, dryRun *DryRun
 			if bootBlockDevice.FsType == "ext2" ||
 				bootBlockDevice.FsType == "ext3" || bootBlockDevice.FsType == "ext4" {
 				legacyExtFsOpt := "-O ^64bit"
-				bootBlockDevice.Options = strings.Join([]string{bootBlockDevice.Options, legacyExtFsOpt}, " ")
+				if len(bootBlockDevice.Options) > 0 {
+					bootBlockDevice.Options = strings.TrimSpace(bootBlockDevice.Options) +
+						" " + strings.TrimSpace(legacyExtFsOpt)
+				} else {
+					bootBlockDevice.Options = strings.TrimSpace(legacyExtFsOpt)
+				}
+
 				log.Warning("setBootPartition: legacy_boot on / requires option: %s", legacyExtFsOpt)
 			}
 		} else {


### PR DESCRIPTION
Changes proposed in this pull request:
- When adding the required options to mkfs for legacy mode on ext, an extra null was being added when options field was empty in the YAML.

