### PR TITLE
ISO: Add integrity check

### DIFF
--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -136,6 +136,13 @@ overlay_and_switch() {
     exec switch_root /mnt/ramfs/rw_root /sbin/init
 }
 
+verify_media() {
+    echo_tty_kmsg "Verifying media"
+    local installer=$(blkid -L CLR_ISO)
+
+    checkisomd5 --verbose --gauge ${installer}
+}
+
 main() {
     # Mount temp filesystem
     mount -t proc none /proc
@@ -151,6 +158,8 @@ main() {
     have_sse41_cpu_feature
     have_sse42_cpu_feature
     have_pclmul_cpu_feature
+
+    verify_media
     echo_tty_kmsg "[${SUCCESS}  OK  ${NORMAL}] All checks passed."
 
     # insmod required modules

--- a/iso_templates/isolinux.cfg.template
+++ b/iso_templates/isolinux.cfg.template
@@ -8,3 +8,10 @@ LABEL clear
   LINUX /kernel/kernel.xz
   INITRD /EFI/BOOT/initrd.gz
   APPEND {{.Options}}
+
+LABEL clear
+  MENU DEFAULT
+  MENU LABEL Test ISO for defects
+  LINUX /kernel/kernel.xz
+  INITRD /EFI/BOOT/initrd.gz
+  APPEND {{.Options}}

--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -526,6 +526,30 @@ func mkLegacyBoot(templatePath string) error {
 	return err
 }
 
+func implantIsoChecksum(imgName string) error {
+	msg := "Adding Checksums for ISO Integrity"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	args := []string{
+		"implantiso",
+	}
+
+	if len(imgName) > 0 {
+		isoName := imgName + ".iso"
+		args = append(args, isoName)
+	}
+
+	err := cmd.RunAndLog(args...)
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	prg.Success()
+	return err
+}
+
 func packageIso(imgName, appID, publisher string) error {
 	msg := "Building ISO"
 	prg := progress.NewLoop(msg)
@@ -641,6 +665,10 @@ func MakeIso(rootDir string, imgName string, model *model.SystemInstall, options
 	}
 
 	if err = packageIso(imgName, appID, model.ISOPublisher); err != nil {
+		return err
+	}
+
+	if err = implantIsoChecksum(imgName); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Karthik Prabhu Vinod <karthik.prabhu.vinod@intel.com>

Fixes Issue: #490

Changes proposed in this pull request:
- Add Boot menu entries for UEFI & legacy boot called "Check for disk defects"
- Add clr-installer code to performing implanting md5 checksums during ISO generation


