### PR TITLE
Fix usage model for offline content

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -219,7 +219,7 @@ func processSwupdOptions(options args.Args, md *model.SystemInstall) {
 		md.SwupdSkipOptional = options.SwupdSkipOptional
 	}
 	if options.SwupdVersion != "" {
-		if strings.EqualFold(options.SwupdVersion, "latest") {
+		if utils.IsLatestVersion(options.SwupdVersion) {
 			md.Version = 0
 		} else {
 			version, err := strconv.ParseUint(options.SwupdVersion, 10, 32)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -63,7 +63,6 @@ func sortMountPoint(bds []*storage.BlockDevice) []*storage.BlockDevice {
 //nolint: gocyclo  // TODO: Refactor this
 func Install(rootDir string, model *model.SystemInstall, options args.Args) error {
 	var err error
-	var version string
 	var prg progress.Progress
 	var encryptedUsed, softRaidUsed bool
 
@@ -100,11 +99,7 @@ func Install(rootDir string, model *model.SystemInstall, options args.Args) erro
 		}
 	}
 
-	if model.Version == 0 {
-		version = "latest"
-	} else {
-		version = fmt.Sprintf("%d", model.Version)
-	}
+	version := utils.VersionUintString(model.Version)
 
 	log.Debug("Clear Linux OS version: %s", version)
 
@@ -574,9 +569,9 @@ func contentInstall(rootDir string, version string,
 
 	// We have usable offline content available
 	if swupd.OfflineIsUsable(version, options) {
-		if version == "latest" {
+		if utils.IsLatestVersion(version) {
+			log.Info("Overriding version from '%s' to %s to enable offline install", version, utils.ClearVersion)
 			version = utils.ClearVersion
-			log.Info("Overriding version from 'latest' to %s to enable offline install", utils.ClearVersion)
 		}
 
 		msg := utils.Locale.Get("Copying cached content to target media")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -583,9 +583,11 @@ func contentInstall(rootDir string, version string,
 		// install over the network.
 		if err := copyOfflineToStatedir(rootDir, sw.GetStateDir()); err != nil {
 			log.Warning("Failed to copy offline content: %s", err)
+			prg.Failure()
+			time.Sleep(time.Second * 2)
+		} else {
+			prg.Success()
 		}
-
-		prg.Success()
 	} else {
 		log.Warning("Ignoring the Offline content (%s) due to version set to %s", utils.ClearVersion, version)
 	}
@@ -712,6 +714,11 @@ func contentInstall(rootDir string, version string,
 }
 
 func copyOfflineToStatedir(rootDir, stateDir string) error {
+	// Force an error for testing
+	if testFail, _ := utils.FileExists(path.Join(conf.OfflineContentDir, "FAIL")); testFail {
+		return fmt.Errorf("Forcing a failing for %s", conf.OfflineContentDir)
+	}
+
 	if err := utils.MkdirAll(filepath.Dir(stateDir), 0755); err != nil {
 		return err
 	}

--- a/gui/window.go
+++ b/gui/window.go
@@ -878,7 +878,8 @@ func (window *Window) confirmInstall() {
 	}
 
 	// Valid network is required to install without offline content or additional bundles
-	if (!swupd.IsOfflineContent() || len(window.model.UserBundles) != 0) && !controller.NetworkPassing {
+	if (!swupd.OfflineIsUsable(utils.VersionUintString(window.model.Version), window.options) ||
+		len(window.model.UserBundles) != 0) && !controller.NetworkPassing {
 		if ret, err := network.RunNetworkTest(window.model); ret == network.NetTestErr {
 			log.Warning("Error running network test: ", err)
 			return
@@ -886,7 +887,7 @@ func (window *Window) confirmInstall() {
 	}
 
 	if !controller.NetworkPassing {
-		if !swupd.IsOfflineContent() {
+		if !swupd.OfflineIsUsable(utils.VersionUintString(window.model.Version), window.options) {
 			// Cannot install without network or offline content
 			return
 		} else if len(window.model.UserBundles) != 0 {

--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -701,3 +701,27 @@ func CopyConfigurations(rootDir string) {
 			filepath.Join(rootDir, swupdConfigOverrideDir))
 	}
 }
+
+// OfflineIsUsable ensures that we have offline content, and
+// that based on our desired version and command line options,
+// that it should be used for the installation.
+func OfflineIsUsable(version string, options args.Args) bool {
+	if IsOfflineContent() {
+		if err := utils.ParseOSClearVersion(); err != nil {
+			return false
+		}
+
+		// If command line did not explicitly set "latest", use the current
+		// image version to enable Offline content usage
+		// Note: Setting "version: 0" in the YAML will not override offline content
+		if utils.IsLatestVersion(version) && options.SwupdVersion == "" {
+			return true
+		}
+
+		if version == utils.ClearVersion {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tui/confirm_install.go
+++ b/tui/confirm_install.go
@@ -12,11 +12,13 @@ import (
 	"github.com/VladimirMarkelov/clui"
 	term "github.com/nsf/termbox-go"
 
+	"github.com/clearlinux/clr-installer/args"
 	"github.com/clearlinux/clr-installer/controller"
 	"github.com/clearlinux/clr-installer/log"
 	"github.com/clearlinux/clr-installer/model"
 	"github.com/clearlinux/clr-installer/storage"
 	"github.com/clearlinux/clr-installer/swupd"
+	"github.com/clearlinux/clr-installer/utils"
 )
 
 // ConfirmInstallDialog is dialog window use to stop all other
@@ -28,6 +30,7 @@ type ConfirmInstallDialog struct {
 	onClose   func()
 
 	modelSI       *model.SystemInstall
+	options       args.Args
 	warningLabel  *clui.Label
 	mediaLabel    *clui.Label
 	mediaDetail   *clui.TextView
@@ -160,7 +163,8 @@ func initConfirmDiaglogWindow(dialog *ConfirmInstallDialog) error {
 		dialog.modelSI.MediaOpts)
 
 	// Create additional bundle removal warning for offline installs
-	if !controller.NetworkPassing && len(dialog.modelSI.UserBundles) != 0 && swupd.IsOfflineContent() {
+	if !controller.NetworkPassing && len(dialog.modelSI.UserBundles) != 0 &&
+		swupd.OfflineIsUsable(utils.VersionUintString(dialog.modelSI.Version), dialog.options) {
 		*dryRunResults.TargetResults = append(*dryRunResults.TargetResults,
 			"Offline Install: Removing additional bundles")
 	}
@@ -188,7 +192,7 @@ func initConfirmDiaglogWindow(dialog *ConfirmInstallDialog) error {
 }
 
 // CreateConfirmInstallDialogBox creates the Network PopUp
-func CreateConfirmInstallDialogBox(modelSI *model.SystemInstall) (*ConfirmInstallDialog, error) {
+func CreateConfirmInstallDialogBox(modelSI *model.SystemInstall, options args.Args) (*ConfirmInstallDialog, error) {
 	dialog := new(ConfirmInstallDialog)
 
 	if dialog == nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 Intel Corporation
+// Copyright © 2020 Intel Corporation
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -496,4 +496,21 @@ func HostHasEFI() bool {
 	}
 
 	return true
+}
+
+//VersionUintString converts a uint model to the string version
+func VersionUintString(versionUint uint) string {
+	var version string
+
+	if versionUint == 0 {
+		version = "latest"
+	} else {
+		version = fmt.Sprintf("%d", versionUint)
+	}
+
+	return version
+}
+
+func IsLatestVersion(version string) bool {
+	return strings.EqualFold(version, "latest")
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Always use offline content by default
- Ensure network check is run before install if offline content won't be used