### PR TITLE
ISO: Add integrity check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,11 @@ PHONY += dev-check-all
 dev-check-all: check-for-root-user build lint functional-check check
 	@echo "Running dev tests have passed"
 
+PHONY += damage
+damage:
+	@echo "Building damage_file"
+	go build tests/damage_file.go
+
 all: build
 
 PHONY += all

--- a/args/args.go
+++ b/args/args.go
@@ -33,7 +33,9 @@ const (
 	kernelCmdlineDemo         = "clri.demo"
 	kernelCmdlineLog          = "clri.loglevel"
 	kernelCmdlineHighContrast = "clri.hc"
-	logFileEnvironVar         = "CLR_INSTALLER_LOG_FILE"
+	// KernelMediaCheck is used to create a verufy ISO media boot menu
+	KernelMediaCheck  = "clri.mediacheck"
+	logFileEnvironVar = "CLR_INSTALLER_LOG_FILE"
 )
 
 var (

--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -8,14 +8,36 @@ WARNING="\\033[1;33m"        # yellow
 FAILURE="\\033[1;31m"        # red
 INFO="\\033[1;36m"           # light cyan
 
+TTY_DEFAULT="/dev/console"
+TTYS="/dev/console /dev/tty0 /dev/ttyS0 /dev/tty1 /dev/ttyS1 /dev/tty2 /dev/ttyS2"
+TTY="${TTY_DEFAULT}"
+
+discover_tty() {
+    found=0
+    for tty in ${TTYS}
+    do
+        echo -e "" >> "${tty}" 2>/dev/null
+        if [ "$?" -eq 0 ] ; then
+            TTY="${tty}"
+            found=1
+            break
+        fi
+    done
+
+    if [ "${found}" -eq 1 ] ; then
+        echo_tty_kmsg "${INFO}Using ${TTY} for output${NORMAL}"
+    else
+        TTY="${TTY_DEFAULT}"
+        echo_tty_kmsg "${FAILURE}Defaulting to ${TTY} for output${NORMAL}"
+    fi
+}
+
 # Prints msg to TTY and kmsg, stripping color codes for kmsg
 # This echos twice - once for tty0 and once on kmsg for all others
 # $1 - Message string to print
 # Explicitly send boot messages to tty0, /dev/console is ttyS0
 echo_tty_kmsg() {
-    echo -e "$1" > /dev/tty0
-    # This is required for messages to be seen while using qemu
-    echo -e "$1" > /dev/console
+    echo -e "$1" > "${TTY}"
     echo -e "$1" | sed 's/\x1b\[[0-9;]*m//g' > /dev/kmsg
 }
 
@@ -128,12 +150,11 @@ verify_media() {
     local need="ISO integrity check"
 
     if [ -n "${installer}" ]; then
-        checkisomd5 --verbose ${installer} 2>&1 | tee -a /dev/console > /dev/tty0
+        checkisomd5 --verbose ${installer} |& tee -a "${TTY}"
+        check_iso_verify "${PIPESTATUS[0]}" "$need"
     else
         shell_trap "[${FAILURE} FAIL ${NORMAL}] Failed to verify installer media, failed to boot Clear Linux*."
     fi
-
-    check_iso_verify "${PIPESTATUS[0]}" "$need"
 }
 
 # Finds the installer media
@@ -196,6 +217,8 @@ main() {
     mount -t sysfs none /sys
     mount -t devtmpfs none /dev
     mount -t tmpfs none /run
+
+    discover_tty
 
     # Verify CPU features needed to run Clear exist
     echo_tty_kmsg "Checking if system is capable of running Clear Linux*..."

--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Set color commands used with echo
 # Refer to man console_codes for more info
@@ -128,20 +128,24 @@ mount_root() {
     fi
 }
 
-wait_for_keystrokes() {
-    while [ true ] ; do
-        read -n 1
-        if [ "$?" -eq 0 ] ; then
-            break
-        fi
+wait_for_timeout() {
+    local n="$1"
+    local space=" "
+    echo_tty_kmsg
+    echo_tty_kmsg
+    while [ "$n" -ge 0 ] ; do
+        printf "Continue booting in [%2d] sec(s)...\r" "$n" > "${TTY}"
+        sleep 1
+        n=`expr "$n" - 1`
     done
+    printf "%50c\r" "$space" > "${TTY}"
 }
 
 check_iso_verify() {
     local ret="$1"
     local msg="$2"
     [ "$ret" -ne 0 ] && { echo_tty_kmsg "[${FAILURE} FAIL ${NORMAL}]"; shell_trap "$msg"; }
-    [ "$ret" -eq 0 ] && { echo_tty_kmsg "[${SUCCESS}  OK  ${NORMAL}] $msg: Press any key to continue"; wait_for_keystrokes; }
+    [ "$ret" -eq 0 ] && { echo_tty_kmsg "[${SUCCESS}  OK  ${NORMAL}] $msg"; wait_for_timeout 10; }
 }
 
 # Check ISO media integrity
@@ -150,7 +154,7 @@ verify_media() {
     local need="ISO integrity check"
 
     if [ -n "${installer}" ]; then
-        checkisomd5 --verbose ${installer} |& tee -a "${TTY}"
+        checkisomd5 --verbose ${installer} > "${TTY}"
         check_iso_verify "${PIPESTATUS[0]}" "$need"
     else
         shell_trap "[${FAILURE} FAIL ${NORMAL}] Failed to verify installer media, failed to boot Clear Linux*."

--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -14,6 +14,8 @@ INFO="\\033[1;36m"           # light cyan
 # Explicitly send boot messages to tty0, /dev/console is ttyS0
 echo_tty_kmsg() {
     echo -e "$1" > /dev/tty0
+    # This is required for messages to be seen while using qemu
+    echo -e "$1" > /dev/console
     echo -e "$1" | sed 's/\x1b\[[0-9;]*m//g' > /dev/kmsg
 }
 
@@ -104,15 +106,45 @@ mount_root() {
     fi
 }
 
-# Finds the installer media and calls mount_root if successful
-find_and_mount_installer() {
+wait_for_keystrokes() {
+    while [ true ] ; do
+        read -n 1
+        if [ "$?" -eq 0 ] ; then
+            break
+        fi
+    done
+}
+
+check_iso_verify() {
+    local ret="$1"
+    local msg="$2"
+    [ "$ret" -ne 0 ] && { echo_tty_kmsg "[${FAILURE} FAIL ${NORMAL}]"; shell_trap "$msg"; }
+    [ "$ret" -eq 0 ] && { echo_tty_kmsg "[${SUCCESS}  OK  ${NORMAL}] $msg: Press any key to continue"; wait_for_keystrokes; }
+}
+
+# Check ISO media integrity
+verify_media() {
+    local installer="$1"
+    local need="ISO integrity check"
+
+    if [ -n "${installer}" ]; then
+        checkisomd5 --verbose ${installer} 2>&1 | tee -a /dev/console > /dev/tty0
+    else
+        shell_trap "[${FAILURE} FAIL ${NORMAL}] Failed to verify installer media, failed to boot Clear Linux*."
+    fi
+
+    check_iso_verify "${PIPESTATUS[0]}" "$need"
+}
+
+# Finds the installer media
+find_installer() {
     local retries=0
 
     while [ $retries -le 5 ]; do
-        local installer=$(blkid -L CLR_ISO)
+        installer=$(blkid -L CLR_ISO)
         if [ -n "${installer}" ]; then
             echo_tty_kmsg "[${SUCCESS}  OK  ${NORMAL}] Found installer media, continuing boot..."
-            mount_root ${installer}
+            echo "$installer"
             break
         else
             echo_tty_kmsg "Searching for installer media, retrying..."
@@ -126,6 +158,17 @@ find_and_mount_installer() {
     fi
 }
 
+# Mounts the installer media found previously
+mount_installer() {
+    local installer="$1"
+
+    if [ -n "${installer}" ]; then
+        mount_root "${installer}"
+    else
+        shell_trap "[${FAILURE} FAIL ${NORMAL}] Failed to mount installer media, failed to boot Clear Linux*."
+    fi
+}
+
 overlay_and_switch() {
     mkdir /mnt/ramfs
     mount -t tmpfs -o size=512M none /mnt/ramfs
@@ -133,7 +176,18 @@ overlay_and_switch() {
     mount -t overlay -o lowerdir=/mnt/rootfs,upperdir=/mnt/ramfs/w_root,workdir=/mnt/ramfs/workdir none /mnt/ramfs/rw_root
 
     # Switch root
-    exec switch_root /mnt/ramfs/rw_root /sbin/init
+    exec switch_root /mnt/ramfs/rw_root /sbin/init 1>/dev/kmsg 2>/dev/kmsg
+}
+
+check_kernel_cmdline_contains() {
+    local optioncheck=${1}
+    local kernelcmdline=$(cat /proc/cmdline)
+    for option in $kernelcmdline; do
+        if [ "$option" == "$optioncheck" ]; then
+          return 0
+        fi
+    done
+    return -1
 }
 
 main() {
@@ -143,7 +197,6 @@ main() {
     mount -t devtmpfs none /dev
     mount -t tmpfs none /run
 
-
     # Verify CPU features needed to run Clear exist
     echo_tty_kmsg "Checking if system is capable of running Clear Linux*..."
     have_64bit_cpu
@@ -151,14 +204,25 @@ main() {
     have_sse41_cpu_feature
     have_sse42_cpu_feature
     have_pclmul_cpu_feature
+
     echo_tty_kmsg "[${SUCCESS}  OK  ${NORMAL}] All checks passed."
+
+    # Find the installer
+    installer=$(find_installer)
+
+    # ISO media integrity check on installer media
+    if check_kernel_cmdline_contains {{.IsoMediaBootOption}}; then
+        echo_tty_kmsg "Starting ISO integrity check..."
+        verify_media "$installer"
+    fi
 
     # insmod required modules
     {{range .Modules}}
     insmod {{.}}
     {{end}}
 
-    find_and_mount_installer
+    # Mount it
+    mount_installer "$installer"
     overlay_and_switch
 }
 

--- a/iso_templates/isolinux.cfg.template
+++ b/iso_templates/isolinux.cfg.template
@@ -8,3 +8,9 @@ LABEL clear
   LINUX /kernel/kernel.xz
   INITRD /EFI/BOOT/initrd.gz
   APPEND {{.Options}}
+
+LABEL verifyiso
+  MENU LABEL Verify ISO Integrity
+  LINUX /kernel/kernel.xz
+  INITRD /EFI/BOOT/initrd.gz
+  APPEND {{.OptionsMediaCheck}}

--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -165,7 +165,7 @@ func mkInitrd(version string, model *model.SystemInstall, options args.Args) err
 	sw := swupd.New(tmpPaths[clrInitrd], options, model)
 
 	/* Install os-core and os-core-plus (we only need kmod-bin) as initrd */
-	if err := sw.OSInstall(version, swupd.IsoPrefix, []string{"os-core-plus"}); err != nil {
+	if err := sw.OSInstall(version, swupd.IsoPrefix, []string{"clr-installer-iso-init"}); err != nil {
 		prg = progress.NewLoop(msg)
 		prg.Failure()
 		return err
@@ -181,9 +181,10 @@ func mkInitrdInitScript(templatePath string) error {
 	log.Info(msg)
 
 	type Modules struct {
-		Modules []string
+		Modules            []string
+		IsoMediaBootOption string
 	}
-	mods := Modules{}
+	mods := Modules{IsoMediaBootOption: args.KernelMediaCheck}
 
 	//Modules to insmod during init, paths relative to the kernel folder
 	modules := []string{
@@ -259,6 +260,10 @@ func mkInitrdInitScript(templatePath string) error {
 		return err
 	}
 
+	log.Debug("Init script contents after template expansion: ")
+	// soft error just needed for logging
+	_ = cmd.RunAndLog("cat", tmpPaths[clrInitrd]+"/init")
+
 	/* Set correct owner and permissions on initrd's init */
 	if err = os.Chown(tmpPaths[clrInitrd]+"/init", 0, 0); err != nil {
 		prg.Failure()
@@ -320,6 +325,21 @@ func buildInitrdImage() error {
 	return err
 }
 
+// We take a copy of options from normal EFI entry and edit it for new EFI entry: /loader/entries/iso-checksum.conf
+func prepareISOCheckSumBootEntry(inputOptions []string) []string {
+	outputOptions := append([]string(nil), inputOptions...)
+	for i, option := range outputOptions {
+		if strings.Contains(option, "title") {
+			outputOptions[i] = "title Verify ISO Integrity"
+		}
+
+		if i == len(outputOptions)-1 {
+			outputOptions[i] = strings.TrimSpace(option) + " " + args.KernelMediaCheck
+		}
+	}
+	return outputOptions
+}
+
 func mkEfiBoot() error {
 	msg := "Building efiboot image"
 	prg := progress.NewLoop(msg)
@@ -342,6 +362,7 @@ func mkEfiBoot() error {
 
 	/* Modify loader/entries/Clear-linux-*, add initrd= line and remove ROOT= from kernel command line options */
 	entriesGlob, err := filepath.Glob(tmpPaths[clrEfi] + "/loader/entries/Clear-linux-*")
+	entriesIsoChecksum := filepath.Join(tmpPaths[clrEfi] + "/loader/entries/iso-checksum.conf")
 	if err != nil || len(entriesGlob) != 1 {
 		prg.Failure()
 		log.Error("Failed to modify efi entries file")
@@ -381,6 +402,14 @@ func mkEfiBoot() error {
 		return err
 	}
 
+	isoBootMenuLines := prepareISOCheckSumBootEntry(lines)
+	err = ioutil.WriteFile(entriesIsoChecksum, []byte(strings.Join(isoBootMenuLines, "\n")), 0644)
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to write kernel boot parameters file for isomd5sum check")
+		return err
+	}
+
 	/* Copy EFI files to the cdroot for Rufus support */
 	cpCmd := []string{"cp", "-pr", tmpPaths[clrEfi] + "/.", tmpPaths[clrCdroot]}
 	err = cmd.RunAndLog(cpCmd...)
@@ -392,6 +421,17 @@ func mkEfiBoot() error {
 	/* Copy initrd to efiboot.img and finally unmount efiboot.img */
 	initrdPaths := []string{tmpPaths[clrCdroot] + "/EFI/BOOT/initrd.gz", tmpPaths[clrEfi] + "/EFI/BOOT/initrd.gz"}
 	err = utils.CopyFile(initrdPaths[0], initrdPaths[1])
+	if err != nil {
+		prg.Failure()
+		return err
+	}
+
+	/*
+		Copy initrd to iso-checksum.conf.
+		If we dont do this, mkLegacyBoot will fail to find it while creating correspoding isolinux entry
+	*/
+	err = utils.CopyFile(tmpPaths[clrEfi]+"/loader/entries/iso-checksum.conf",
+		tmpPaths[clrImgEfi]+"/loader/entries/iso-checksum.conf")
 	if err != nil {
 		prg.Failure()
 		return err
@@ -413,7 +453,8 @@ func mkLegacyBoot(templatePath string) error {
 	log.Info(msg)
 
 	type BootConf struct {
-		Options string
+		Options           string
+		OptionsMediaCheck string
 	}
 	bc := BootConf{}
 
@@ -458,6 +499,27 @@ func mkLegacyBoot(templatePath string) error {
 		return err
 	}
 
+	// inner Function to remove filter unwanted parts like PARTUUID, word: `option` for different boot menus
+	filterOptionsLineFunc := func(optionLine []byte) string {
+		/* Read options from the EFI partition, remove the string 'options' and root=PARTUUID from the options line */
+		lines := strings.Split(string(optionLine), "\n")
+		var optionsLineTemp string
+		for _, line := range lines {
+			if strings.Contains(line, "options") {
+				optionsLineTemp = line
+			}
+		}
+
+		options := strings.Split(optionsLineTemp, " ")
+		for i, option := range options {
+			if strings.Contains(option, "options") || strings.Contains(option, "PARTUUID") {
+				options[i] = ""
+			}
+		}
+
+		return strings.Join(options, " ")
+	}
+
 	/* Find the (kernel boot) options file, load it into bc.Options */
 	optionsGlob, err := filepath.Glob(tmpPaths[clrImgEfi] + "/loader/entries/Clear-linux-*")
 	if err != nil || len(optionsGlob) > 1 { // Fail if there's >1 match
@@ -472,22 +534,24 @@ func mkLegacyBoot(templatePath string) error {
 		return err
 	}
 
-	/* Read options from the EFI partition, remove the string 'options' and root=PARTUUID from the options line */
-	lines := strings.Split(string(optionsFile), "\n")
-	var optionsLine string
-	for _, line := range lines {
-		if strings.Contains(line, "options") {
-			optionsLine = line
-		}
+	bc.Options = filterOptionsLineFunc(optionsFile)
+
+	// ISO Integrity boot option
+	entriesIsoChecksum, err := filepath.Glob(tmpPaths[clrImgEfi] + "/loader/entries/iso-checksum*")
+	if err != nil || len(entriesIsoChecksum) > 1 { // Fail if there's >1 match
+		prg.Failure()
+		log.Error("Failed to determine boot options for ISO Integrity check")
+		return err
 	}
 
-	options := strings.Split(optionsLine, " ")
-	for i, option := range options {
-		if strings.Contains(option, "options") || strings.Contains(option, "PARTUUID") {
-			options[i] = ""
-		}
+	optionsFileISO, err := ioutil.ReadFile(entriesIsoChecksum[0])
+	if err != nil {
+		prg.Failure()
+		log.Error("Failed to read options file from iso boot menu")
+		return err
 	}
-	bc.Options = string(strings.Join(options, " "))
+
+	bc.OptionsMediaCheck = filterOptionsLineFunc(optionsFileISO)
 
 	/* Fill boot options in isolinux.cfg */
 	tmpl, err := ioutil.ReadFile(templatePath + "/isolinux.cfg.template")
@@ -519,6 +583,30 @@ func mkLegacyBoot(templatePath string) error {
 	if err != nil {
 		prg.Failure()
 		log.Error("Failed to execute template filling")
+		return err
+	}
+
+	prg.Success()
+	return err
+}
+
+func implantIsoChecksum(imgName string) error {
+	msg := "Adding Checksums for ISO Integrity"
+	prg := progress.NewLoop(msg)
+	log.Info(msg)
+
+	args := []string{
+		"implantisomd5",
+	}
+
+	if len(imgName) > 0 {
+		isoName := imgName + ".iso"
+		args = append(args, isoName)
+	}
+
+	err := cmd.RunAndLog(args...)
+	if err != nil {
+		prg.Failure()
 		return err
 	}
 
@@ -641,6 +729,10 @@ func MakeIso(rootDir string, imgName string, model *model.SystemInstall, options
 	}
 
 	if err = packageIso(imgName, appID, model.ISOPublisher); err != nil {
+		return err
+	}
+
+	if err = implantIsoChecksum(imgName); err != nil {
 		return err
 	}
 

--- a/tests/damage_file.go
+++ b/tests/damage_file.go
@@ -1,0 +1,99 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Test program to inject random bytes into image files
+// to help validate ISO checksums are working.
+
+// Build: go build damage_file.go
+// Usage: damage_file my.iso
+
+package main
+
+import (
+	"crypto/rand"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+)
+
+func main() {
+	prog := path.Base(os.Args[0])
+
+	var damageFile string
+	var offset, count int64
+
+	fs := flag.NewFlagSet(prog, flag.ExitOnError)
+
+	fs.StringVar(&damageFile, "file", "", "File to be damaged")
+	fs.Int64Var(&offset, "offset", -4194304, "Byte offset where to start damage")
+	fs.Int64Var(&count, "count", 1024, "Number of bytes to damage")
+
+	var Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage of %s:\n", prog)
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fmt.Printf("Error: Failed to parse: %+v\n", os.Args[1:])
+		os.Exit(1)
+	}
+
+	if len(damageFile) < 1 {
+		Usage()
+		os.Exit(1)
+	}
+
+	srcFile, err := os.OpenFile(damageFile, os.O_RDWR, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("No such file: %s\n", damageFile)
+		}
+		fmt.Printf("Failed to open '%s': %s\n", damageFile, err)
+		os.Exit(1)
+	}
+	defer srcFile.Close()
+
+	// 0 means relative to the origin of the file,
+	// 1 means relative to the current offset, and
+	// 2 means relative to the end.
+	whence := 0
+	if offset < 0 {
+		whence = 2
+	}
+
+	// Save the EOF
+	saveEOF, err := srcFile.Seek(0, 2)
+	if err != nil {
+		fmt.Printf("Failed to seek '%s': %s\n", damageFile, err)
+		os.Exit(1)
+	}
+
+	newPosition, err := srcFile.Seek(offset, whence)
+	if err != nil {
+		fmt.Printf("Failed to seek '%s': %s\n", damageFile, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Injecting %d zero bytes at position %d for %s\n", count, newPosition, damageFile)
+
+	damage := make([]byte, count)
+	if _, err := rand.Read(damage); err != nil {
+		fmt.Printf("Failed to generate random data: %s\n", err)
+		os.Exit(1)
+	}
+
+	if cnt, err := srcFile.Write(damage); err != nil {
+		fmt.Printf("Failed to write into '%s' (%d): %s\n", damageFile, cnt, err)
+		os.Exit(1)
+	} else {
+		fmt.Printf(" Injected %d zero bytes at position %d for %s\n", cnt, newPosition, damageFile)
+	}
+
+	// Seek to the end of the file
+	if _, err := srcFile.Seek(saveEOF, 2); err != nil {
+		fmt.Printf("Failed to seek to end-of-file '%s': %s\n", damageFile, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Fixes Issue: #490 

Changes proposed in this pull request:
- [x] Adding Implant code
- [x] initramFs Add verify checksum using checkisomd5
- [x] BIOS/UEFI menu changes
- [x] Template changes during InitRd making & creating isolinux boot menus
- [x] While making initRd, make swupd install clr-installer-iso-init instead of clr-init
- [x] Adding a new conf file to have a UEFI menu to trigger a ISO media integrity

Signed-off-by: Karthik Prabhu Vinod <karthik.prabhu.vinod@intel.com>
