### PR TITLE
Fix JSON decoding of ister Version

### DIFF
--- a/clr-installer/main.go
+++ b/clr-installer/main.go
@@ -219,16 +219,11 @@ func processSwupdOptions(options args.Args, md *model.SystemInstall) {
 		md.SwupdSkipOptional = options.SwupdSkipOptional
 	}
 	if options.SwupdVersion != "" {
-		if utils.IsLatestVersion(options.SwupdVersion) {
-			md.Version = 0
+		if version, err := utils.VersionStringUint(options.SwupdVersion); err == nil {
+			md.Version = version
+			log.Debug("Forcing Clear Linux OS version to %d", md.Version)
 		} else {
-			version, err := strconv.ParseUint(options.SwupdVersion, 10, 32)
-			if err == nil {
-				md.Version = uint(version)
-				log.Debug("Forcing Clear Linux OS version to %d", md.Version)
-			} else {
-				log.Warning("Failed to parse swupd-version : %s; not-used!", options.SwupdVersion)
-			}
+			log.Warning("Failed to parse swupd-version : %s; not-used!", options.SwupdVersion)
 		}
 	}
 	if options.CopySwupdSet {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -5,6 +5,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -771,5 +772,70 @@ func TestSetDefaultSwapFilePass(t *testing.T) {
 	si.ResetDefaultSwapFileSize()
 	if si.MediaOpts.SwapFileSize == "" {
 		t.Fatalf("SwapFileSize should be set to %q, but it is empty", testValue)
+	}
+}
+
+func TestJSONUnmarshalIster(t *testing.T) {
+	var us IsterConfig
+
+	if err := json.Unmarshal([]byte(`{"Version" "latest"}`), &us); err == nil {
+		t.Fatalf("UnmarshalJSON should have had an error")
+	} else {
+		t.Logf("Found expected error: %+v", err)
+	}
+
+	if err := json.Unmarshal([]byte(`{"Version": 0.567}`), &us); err == nil {
+		t.Fatalf("UnmarshalJSON should have had an error")
+	} else {
+		t.Logf("Found expected error: %+v", err)
+	}
+
+	if err := json.Unmarshal([]byte(`{"Version": "latest"}`), &us); err != nil {
+		t.Fatalf("UnmarshalJSON error %+v", err)
+	}
+	if us.Version.Number != 0 {
+		t.Fatalf("Version latest should always be 0")
+	}
+
+	if err := json.Unmarshal([]byte(`{"Version": ""}`), &us); err != nil {
+		t.Fatalf("UnmarshalJSON error %+v", err)
+	}
+	if us.Version.Number != 0 {
+		t.Fatalf("Version '' should always be 0")
+	}
+
+	if err := json.Unmarshal([]byte(`{"Version": 0}`), &us); err != nil {
+		t.Fatalf("UnmarshalJSON error %+v", err)
+	}
+	if us.Version.Number != 0 {
+		t.Fatalf("Version '0' should always be 0, not %d", us.Version.Number)
+	}
+
+	if err := json.Unmarshal([]byte(`{"Version": "10"}`), &us); err != nil {
+		t.Fatalf("UnmarshalJSON error %+v", err)
+	}
+	if us.Version.Number != 10 {
+		t.Fatalf("Version \"10\" should always be 10, not %d", us.Version.Number)
+	}
+
+	if err := json.Unmarshal([]byte(`{"Version": 10}`), &us); err != nil {
+		t.Fatalf("UnmarshalJSON error %+v", err)
+	}
+	if us.Version.Number != 10 {
+		t.Fatalf("Version 10 should always be 10, not %d", us.Version.Number)
+	}
+
+	if err := json.Unmarshal([]byte(`{"Version": "54321"}`), &us); err != nil {
+		t.Fatalf("UnmarshalJSON error %+v", err)
+	}
+	if us.Version.Number != 54321 {
+		t.Fatalf("Version \"54321\" should always be 54321, not %d", us.Version.Number)
+	}
+
+	if err := json.Unmarshal([]byte(`{"Version": 54321}`), &us); err != nil {
+		t.Fatalf("UnmarshalJSON error %+v", err)
+	}
+	if us.Version.Number != 54321 {
+		t.Fatalf("Version 54321 should always be 54321, not %d", us.Version.Number)
 	}
 }

--- a/tests/coverage-curr-status
+++ b/tests/coverage-curr-status
@@ -19,7 +19,7 @@ ok  	github.com/clearlinux/clr-installer/hostname	0.010s	coverage: 100.0% of sta
 ?   	github.com/clearlinux/clr-installer/local-travis	[no test files]
 ok  	github.com/clearlinux/clr-installer/log	0.104s	coverage: 100.0% of statements
 ?   	github.com/clearlinux/clr-installer/massinstall	[no test files]
-ok  	github.com/clearlinux/clr-installer/model	0.031s	coverage: 91.0% of statements
+ok  	github.com/clearlinux/clr-installer/model	0.031s	coverage: 90.0% of statements
 ok  	github.com/clearlinux/clr-installer/network	4.525s	coverage: 26.9% of statements
 ?   	github.com/clearlinux/clr-installer/progress	[no test files]
 ?   	github.com/clearlinux/clr-installer/proxy	[no test files]

--- a/tests/coverage-curr-status
+++ b/tests/coverage-curr-status
@@ -30,4 +30,4 @@ ok  	github.com/clearlinux/clr-installer/telemetry	0.758s	coverage: 41.9% of sta
 ?   	github.com/clearlinux/clr-installer/timezone	[no test files]
 ?   	github.com/clearlinux/clr-installer/tui	[no test files]
 ok  	github.com/clearlinux/clr-installer/user	0.032s	coverage: 25.5% of statements
-ok  	github.com/clearlinux/clr-installer/utils	0.005s	coverage: 10.8% of statements
+ok  	github.com/clearlinux/clr-installer/utils	0.005s	coverage: 20.0% of statements

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -498,7 +499,23 @@ func HostHasEFI() bool {
 	return true
 }
 
-//VersionUintString converts a uint model to the string version
+//VersionStringUint converts string version to an uint version
+func VersionStringUint(versionString string) (uint, error) {
+	var versionUint uint = 0
+
+	if versionString == "" || IsLatestVersion(versionString) {
+		return 0, nil
+	}
+
+	version, err := strconv.ParseUint(versionString, 10, 32)
+	if err == nil {
+		versionUint = uint(version)
+	}
+
+	return versionUint, err
+}
+
+//VersionUintString converts an uint version to the string version
 func VersionUintString(versionUint uint) string {
 	var version string
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -156,3 +156,45 @@ func compareFiles(pathSrc, pathDest string) error {
 
 	return nil
 }
+
+func TestVersion(t *testing.T) {
+	versionString := VersionUintString(0)
+	if !IsLatestVersion(versionString) {
+		t.Fatalf("Version 0 should always be latest")
+	}
+
+	if num, err := VersionStringUint(versionString); err != nil {
+		t.Fatalf("Parse Error: Version latest should always be 0")
+	} else if num != 0 {
+		t.Fatalf("Version latest should always be 0")
+	} else {
+		t.Logf("Found version %d for '%s'", num, versionString)
+	}
+
+	versionString = ""
+	if num, err := VersionStringUint(versionString); err != nil {
+		t.Fatalf("Parse Error: Version '' should always be 0")
+	} else if num != 0 {
+		t.Fatalf("Version '' should always be 0")
+	} else {
+		t.Logf("Found version %d for '%s'", num, versionString)
+	}
+
+	versionString = "0"
+	if num, err := VersionStringUint(versionString); err != nil {
+		t.Fatalf("Parse Error: Version '0' should always be 0")
+	} else if num != 0 {
+		t.Fatalf("Version '0' should always be 0")
+	} else {
+		t.Logf("Found version %d for '%s'", num, versionString)
+	}
+
+	versionString = "10"
+	if num, err := VersionStringUint(versionString); err != nil {
+		t.Fatalf("Parse Error: Version '10' should always be 10")
+	} else if num != 10 {
+		t.Fatalf("Version '10' should always be 10")
+	} else {
+		t.Logf("Found version %d for '%s'", num, versionString)
+	}
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix how JSON Version field is decoded when reading ister configuration files
- Go 1.14.x now fails json.Number with invalid values


