### PR TITLE
controller: Fix hang bug for cbm fails

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -662,7 +662,6 @@ func contentInstall(rootDir string, version string,
 		if err := sw.DisableUpdate(); err != nil {
 			warnMsg := utils.Locale.Get("Disabling automatic updates failed")
 			log.Warning(warnMsg)
-			prg.Failure()
 			return prg, err
 		}
 		prg.Success()
@@ -694,7 +693,6 @@ func contentInstall(rootDir string, version string,
 
 	err := cmd.RunAndLogWithEnv(envVars, args...)
 	if err != nil {
-		prg.Failure()
 		return prg, errors.Wrap(err)
 	}
 	prg.Success()


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix installer hang when clr-boot-manager fails
