### PR TITLE
isoutils: Remove extraneous double quotes

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -347,7 +347,7 @@ func mkEfiBoot() error {
 
 	cmds := [][]string{
 		{"fallocate", "-l", "100M", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
-		{"mkfs.fat", "-n", "\"CLEAR_EFI\"", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
+		{"mkfs.fat", "-n", "CLEAR_EFI", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
 		{"mount", "-t", "vfat", "-o", "loop", tmpPaths[clrCdroot] + "/EFI/efiboot.img", tmpPaths[clrEfi]},
 		{"cp", "-pr", tmpPaths[clrImgEfi] + "/.", tmpPaths[clrEfi]},
 	}


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove extraneous quotes from DOS label
