### PR TITLE
Update efi partition to 124M from 100M

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -346,7 +346,7 @@ func mkEfiBoot() error {
 	log.Info(msg)
 
 	cmds := [][]string{
-		{"fallocate", "-l", "100M", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
+		{"fallocate", "-l", "124M", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
 		{"mkfs.fat", "-n", "CLEAR_EFI", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
 		{"mount", "-t", "vfat", "-o", "loop", tmpPaths[clrCdroot] + "/EFI/efiboot.img", tmpPaths[clrEfi]},
 		{"cp", "-pr", tmpPaths[clrImgEfi] + "/.", tmpPaths[clrEfi]},


### PR DESCRIPTION
ISO creation has been failing because 100M initrd and
the kernel have grown too large for the allocated space.
Eventually we will add this value to yaml config but for
now we will just bump it.

Changes proposed in this pull request:
-Update efi partition to 124M from 100M

