### PR TITLE
Let systemd check kernel command line options

### DIFF
--- a/etc/systemd/clr-installer-provision.service
+++ b/etc/systemd/clr-installer-provision.service
@@ -20,7 +20,8 @@ ConditionKernelCommandLine=clri.descriptor
 [Service]
 Type=oneshot
 ExecStartPre=-/usr/bin/cat /etc/issue
-ExecStart=/bin/bash -l -c 'until /usr/bin/clr-installer ; do echo "clr-installer failed...retying"; sleep 5 ; done ; /usr/bin/reboot'
+ExecStart=/usr/bin/clr-installer
+ExecStartPost=/usr/bin/reboot
 StandardInput=tty
 StandardOutput=tty
 StandardError=tty

--- a/etc/systemd/clr-installer-provision.service
+++ b/etc/systemd/clr-installer-provision.service
@@ -15,10 +15,10 @@
 Description=Clear Linux OS Installer
 After=systemd-user-sessions.service plymouth-quit.service getty@tty1.service
 Conflicts=getty@tty1.service getty@tty0.service serial-getty@ttyS0.service
+ConditionKernelCommandLine=clri.descriptor
 
 [Service]
 Type=oneshot
-ExecStartPre=/bin/bash -l -c 'grep --quiet --no-message clri.descriptor= /proc/cmdline || (echo "Missing clr-install YAML on kernel command line" ; /bin/false)'
 ExecStartPre=-/bin/bash -l -c '/usr/bin/cat /etc/issue'
 ExecStart=/bin/bash -l -c 'until /usr/bin/clr-installer ; do echo "clr-installer failed...retying"; sleep 5 ; done ; /usr/bin/reboot'
 StandardInput=tty

--- a/etc/systemd/clr-installer-provision.service
+++ b/etc/systemd/clr-installer-provision.service
@@ -19,7 +19,7 @@ ConditionKernelCommandLine=clri.descriptor
 
 [Service]
 Type=oneshot
-ExecStartPre=-/bin/bash -l -c '/usr/bin/cat /etc/issue'
+ExecStartPre=-/usr/bin/cat /etc/issue
 ExecStart=/bin/bash -l -c 'until /usr/bin/clr-installer ; do echo "clr-installer failed...retying"; sleep 5 ; done ; /usr/bin/reboot'
 StandardInput=tty
 StandardOutput=tty

--- a/etc/systemd/clr-installer-provision.service
+++ b/etc/systemd/clr-installer-provision.service
@@ -22,10 +22,9 @@ Type=oneshot
 ExecStartPre=-/usr/bin/cat /etc/issue
 ExecStart=/usr/bin/clr-installer
 ExecStartPost=/usr/bin/reboot
-StandardInput=tty
-StandardOutput=tty
-StandardError=tty
-TTYPath=/dev/console
+StandardInput=tty-force
+StandardOutput=tty-force
+StandardError=tty-force
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Cleanup for `clr-installer-provision.service`. Trying to avoid extra embedded bash calls -- use systemd's internal capabilties instead of relying on bashisms.

Fixes Issue: #

Changes proposed in this pull request:
- Avoid using bash calls as much as possible
- Use systemd's built-in ConditionKernelCommandLine directive to detect clri.descriptor to decide whether to run
- Allow this unit to take over the console (was blocking, attempting askpass, while getty was active)
- Call cat directly to print /etc/issue to console (instead of from bash)
- Call clr-installer directly instead of from a bash loop -- should implement retries via systemd's mechanisms instead
- Call reboot directly as a post action only if/after the installer succeeded


