### PR TITLE
Show found partitions while we're looking for CLR_ISO

### DIFF
--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -177,6 +177,7 @@ find_installer() {
             sleep 1
             (( retries++ ))
         fi
+        blkid
     done
 
     if [ $retries -ge $max_retries ]; then

--- a/iso_templates/initrd_init_template
+++ b/iso_templates/initrd_init_template
@@ -177,7 +177,9 @@ find_installer() {
             sleep 1
             (( retries++ ))
         fi
-        blkid
+        blkid | while read partition; do
+            echo_tty_kmsg "${partition}"
+        done
     done
 
     if [ $retries -ge $max_retries ]; then


### PR DESCRIPTION
initrd calls blkid a few times looking for CLR_ISO, so it can identify the root device that was booted. On each retry, call blkid plain to show everything that's been found -- this may help with debugging boot failures.

