### PR TITLE
Fix links to external documentation redirecting to 404 pages

### DIFF
--- a/swupd/swupd.go
+++ b/swupd/swupd.go
@@ -58,7 +58,7 @@ const (
 	AutoUpdateCommand = "\"swupd autoupdate --enable\""
 
 	// AutoUpdateLink specifies document link of auto updates
-	AutoUpdateLink = "https://docs.01.org/clearlinux/latest/guides/clear/swupd.html"
+	AutoUpdateLink = "https://docs.01.org/clearlinux/guides/clear/swupd.html"
 
 	// AutoUpdateLabel specifies label of auto updates
 	AutoUpdateLabel = "Enable Auto Updates"

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -45,7 +45,7 @@ is collected.
 `
 
 	// TelemetryAboutURL is the URL to reference for telemetry details
-	TelemetryAboutURL = `https://docs.01.org/clearlinux/latest/guides/clear/telemetrics.html`
+	TelemetryAboutURL = `https://docs.01.org/clearlinux/guides/clear/telemetrics.html`
 
 	// telemetry controlling interface command
 	telemctlCmd = "telemctl"


### PR DESCRIPTION
Changes proposed in this pull request:
- Update the more info URL for telemetry to no longer show a 404 page
- Update the more info URL for auto updating to no longer show a 404 page

