### PR TITLE
Support compressed kernel modules

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -194,6 +194,13 @@ func mkInitrdInitScript(templatePath string) error {
 		"/kernel/fs/overlayfs/overlay.ko",
 	}
 
+	//Compression extensions
+	compressionExtensions := []string{
+		".zst",
+		".gz",
+		".xz",
+	}
+
 	/* Find kernel, then break the name into kernelVersion */
 	kernelGlob, err := filepath.Glob(tmpPaths[clrRootfs] + "/lib/kernel/org.clearlinux.*")
 	if err != nil || len(kernelGlob) != 1 {
@@ -208,6 +215,15 @@ func mkInitrdInitScript(templatePath string) error {
 	/* Copy files to initrd, and add to mods so they're added to the init template */
 	for _, i := range modules {
 		rootfsModPath := tmpPaths[clrRootfs] + "/usr/lib/modules/" + kernelVersion + "." + kernelType + i
+
+		/* check for compression extensions on module filenames */
+		for _, ext := range compressionExtensions {
+			if _, err := os.Stat(rootfsModPath + ext); err == nil {
+				rootfsModPath = rootfsModPath + ext
+				i = i + ext
+				break
+			}
+		}
 
 		/* copy kernel module to initramfs */
 		initrdModPath := filepath.Dir(tmpPaths[clrInitrd] + "/usr/lib/modules/" + kernelVersion + "." + kernelType + i)

--- a/tests/baseline.yaml
+++ b/tests/baseline.yaml
@@ -21,12 +21,12 @@ targetMedia:
   - name: ${baseimg}1
     fstype: vfat
     mountpoint: /boot
-    size: "50M"
+    size: "100M"
     type: part
   - name: ${baseimg}2
     fstype: ext4
     mountpoint: /
-    size: "2.0G"
+    size: "4.0G"
     type: part
 
 bundles: [os-core, os-core-update, NetworkManager,  vim]


### PR DESCRIPTION
When generating an ISO image, we have a fixed list of kernel modules that should be included. Add logic to determine whether those kernel modules are named `*.ko.zst`, `*.ko.gz`, or `*.ko.xz` instead of only `*.ko`.