### PR TITLE
Increase default EFI partition size to 512 MB

### DIFF
--- a/storage/block_devices.go
+++ b/storage/block_devices.go
@@ -205,7 +205,7 @@ var (
 		"/dev/mmcblk": "p",
 	}
 
-	bootSizeDefault     = uint64(150 * (1024 * 1024))
+	bootSizeDefault     = uint64(512 * (1024 * 1024))
 	SwapFileSizeDefault = uint64(64 * (1024 * 1024))
 
 	// BlockDeviceTypeLVM2GroupString is a string version for LVM2 member type


### PR DESCRIPTION
With increased initrd sizes, 150 MB is inadequate.

See https://github.com/clearlinux/distribution/issues/3192