### PR TITLE
Increase boot partition size for ISO images

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -362,7 +362,7 @@ func mkEfiBoot() error {
 	log.Info(msg)
 
 	cmds := [][]string{
-		{"fallocate", "-l", "192M", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
+		{"fallocate", "-l", "256M", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
 		{"mkfs.fat", "-n", "CLEAR_EFI", tmpPaths[clrCdroot] + "/EFI/efiboot.img"},
 		{"mount", "-t", "vfat", "-o", "loop", tmpPaths[clrCdroot] + "/EFI/efiboot.img", tmpPaths[clrEfi]},
 		{"cp", "-pr", tmpPaths[clrImgEfi] + "/.", tmpPaths[clrEfi]},


### PR DESCRIPTION
ISO initrd is necessarily much bigger than normal initrd, so make sure we have enough space for it.

**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: `write /tmp/clrEfi-3358930490/EFI/BOOT/initrd.gz: no space left on device`

Changes proposed in this pull request:
-
- bump EFI boot image to 256


