### PR TITLE
Use -iso-level 3

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -638,6 +638,7 @@ func packageIso(imgName, appID, publisher string) error {
 	args := []string{
 		"xorriso", "-as", "mkisofs",
 		"-o", imgName + ".iso",
+		"-iso-level", "3",
 		"-V", "CLR_ISO",
 	}
 


### PR DESCRIPTION
This change allows the creation of an ISO with a rootfs image of size greater than 4GB.

Fixes Issue: [distribution#3283](https://github.com/clearlinux/distribution/issues/3283)

Changes proposed in this pull request:
- Use `iso-level 3` option during ISO creation.


